### PR TITLE
feat(layout): make ::first-letter a real inline box and give abs-pos boxes a static position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [0.0.14] - 2026-08-06 (current)
 
-CSS 2.1 conformance pass: **+1258 upstream reftests**. The WPT `css/CSS2` suite goes from
-**2554/6266 (40.8%)** to **3812/6266 (60.8%)**. The largest movers are `selectors` 93 → 495,
+CSS 2.1 conformance pass: **+1260 upstream reftests**. The WPT `css/CSS2` suite goes from
+**2554/6266 (40.8%)** to **3814/6266 (60.9%)**. The largest movers are `selectors` 93 → 495,
 `normal-flow` 183 → 480, `margin-padding-clear` 388 → 528, `positioning` 203 → 299,
 `borders` 296 → 370, `linebox` 82 → 117, `tables` 39 → 72, `backgrounds` 136 → 169,
-`syntax` 180 → 210, `generated-content` 99 → 129 and `floats-clear` 42 → 72. One directory
+`syntax` 180 → 211, `generated-content` 99 → 130 and `floats-clear` 42 → 72. One directory
 regressed: `abspos` 7 → 5, both cases styling the root element itself as a fixed-position
 table.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.0.14] - 2026-08-06 (current)
 
-CSS 2.1 conformance pass: **+1288 upstream reftests**. The WPT `css/CSS2` suite goes from
-**2554/6266 (40.8%)** to **3842/6266 (61.3%)**. The largest movers are `selectors` 93 → 495,
+CSS 2.1 conformance pass: **+1363 upstream reftests**. The WPT `css/CSS2` suite goes from
+**2554/6266 (40.8%)** to **3917/6266 (62.5%)**. The largest movers are `selectors` 93 → 495,
 `normal-flow` 183 → 479, `margin-padding-clear` 388 → 528, `positioning` 203 → 314,
-`borders` 296 → 370, `backgrounds` 136 → 184, `linebox` 82 → 117, `tables` 39 → 72,
+`tables` 39 → 145, `borders` 296 → 370, `backgrounds` 136 → 184, `linebox` 82 → 117,
 `generated-content` 99 → 130, `syntax` 180 → 210 and `floats-clear` 42 → 72. One directory
 regressed: `abspos` 7 → 5, both cases styling the root element itself as a fixed-position
 table.
@@ -31,6 +31,10 @@ table.
 - **`background` shorthand and its longhands (§14.2)** — the shorthand is expanded from the rule's declared text (tokens classified by shape, so order does not matter) and resets the components it omits; `background-repeat` and `background-position` no longer pass AngleSharp's literal `"initial"` and tuple form `"(initial, 50%)"` through to the painter, which read as "no repeat" and "position 0" respectively (`Parser`, `DrawCommandExtensions`)
 - **`min-width` / `max-width` on in-flow blocks (§10.4)** — only the absolutely-positioned path clamped, so neither property had any effect on a normal block; a box the clamp gives a known width to now centres under auto margins like an explicitly-sized one (`BoxEngine`)
 - **Replaced-element sizing (§10.3.2 / §10.6.2)** — a CSS `width`/`height` on an inline `<img>` is honoured (the inline path read only the intrinsic pixel size), and HTML's `width`/`height` content attributes are treated as presentational hints for those properties rather than as the intrinsic size — reading them as intrinsic dropped percentages outright and mixed axes, so `width="100%" height="50"` on a 1×1 image derived a height of 39200px (`BoxEngine`, `Parser`)
+- **Anonymous table boxes track the DOM** — the normalization pass only ever ADDED wrappers, so it could not follow a change to a display value: setting a cell to `display: none` wrapped it in an anonymous cell + table (a `display: none` box is not a proper table child) and restoring `table-cell` left the wrappers behind. Each pass now dissolves the boxes it generated before regenerating them. The box generated around cells misparented inside an *inline* box is an `inline-table` per §17.2.1, so cells written between inline text no longer break the line (`BoxEngine`)
+- **Absolutely positioned tables and flex containers** — an out-of-flow box laid its children out as plain blocks whatever its own display was, so an abs-pos `<table>` flowed its rows and cells as inline content. Child layout now dispatches on the box's own display, as the in-flow path does (`BoxEngine`)
+- **`cellspacing` / `cellpadding`** — the HTML 4 §11.2.1 presentational hints were ignored, so the UA defaults (2px `border-spacing`, 1px cell padding) stayed in place and a `cellpadding="0" cellspacing="0"` table sat 3px lower and wider than its CSS equivalent (`Parser`)
+- **`! important` with whitespace after the bang** — the declaration parser matched only the literal token, so the spaced form was read as part of the value (`Parser`)
 - **Anonymous table boxes** — a synthesized box borrows its originating element's style object, so a parent's non-inherited `position: absolute` or `float` read back as its own and took it out of flow; a table's intrinsic width came out zero because its rows are neither block-level nor inline. Both are fixed, so an anonymous table inside a float or an abs-pos box now shrink-wraps and lays its cells out side by side (`LayoutNode`, `IntrinsicSizer`, `BoxEngine`)
 - **Attributes** — every authored attribute reaches the layout node, so attribute selectors, `getAttribute` and `attr()` in `content` see what the markup declared; only `data-*` and a per-tag whitelist used to survive (`Parser`)
 - **`line-height: 0`** — text measurement used 0 as the sentinel for "unspecified" and silently substituted the 1.4em default (`TextMeasure`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [0.0.14] - 2026-08-06 (current)
 
-CSS 2.1 conformance pass: **+1260 upstream reftests**. The WPT `css/CSS2` suite goes from
-**2554/6266 (40.8%)** to **3814/6266 (60.9%)**. The largest movers are `selectors` 93 → 495,
-`normal-flow` 183 → 480, `margin-padding-clear` 388 → 528, `positioning` 203 → 299,
-`borders` 296 → 370, `linebox` 82 → 117, `tables` 39 → 72, `backgrounds` 136 → 169,
-`syntax` 180 → 211, `generated-content` 99 → 130 and `floats-clear` 42 → 72. One directory
+CSS 2.1 conformance pass: **+1288 upstream reftests**. The WPT `css/CSS2` suite goes from
+**2554/6266 (40.8%)** to **3842/6266 (61.3%)**. The largest movers are `selectors` 93 → 495,
+`normal-flow` 183 → 479, `margin-padding-clear` 388 → 528, `positioning` 203 → 314,
+`borders` 296 → 370, `backgrounds` 136 → 184, `linebox` 82 → 117, `tables` 39 → 72,
+`generated-content` 99 → 130, `syntax` 180 → 210 and `floats-clear` 42 → 72. One directory
 regressed: `abspos` 7 → 5, both cases styling the root element itself as a fixed-position
 table.
 
@@ -27,6 +27,8 @@ table.
 - **Explicit zero sizes** — `width: 0` / `height: 0` were read as "no size specified" (layout tested `GetWidth() > 0`), so a zero-width box filled its container and a zero-height box grew to its content (`BoxEngine`, `DrawCommandExtensions`)
 - **Invalid negative lengths** — a negative `width`, `height`, `min-`/`max-` pair or `border-width` is invalid, so the declaration is dropped and the property keeps its initial value; `border-top-width: -1px` beside a visible `border-top-style` now paints the initial `medium` (`DrawCommandExtensions`)
 - **Root-relative URL resolution** — `Uri.TryCreate(…, UriKind.Absolute)` accepts `/fonts/ahem.css` as an implicit `file:` URI on Unix, so every root-relative stylesheet, image and form action was handed to the HTTP client unresolved. All resolution goes through a shared `UrlUtils` that treats only a real scheme as absolute (`UrlUtils` and all callers)
+- **Auto margins on absolutely positioned boxes (§10.3.7 / §10.6.4)** — with the offsets and the size all given, an auto margin takes the space the containing block has left over and two of them split it, which is how such a box is centred; they used to compute to zero. Rule 1's static position also follows `direction`, so an RTL containing block puts a box with both offsets auto flush right. Auto-margin detection reads the node's own resolved value, so a margin set by script or by the engine's cascade counts (`BoxEngine`, `DrawCommandExtensions`)
+- **`background` shorthand and its longhands (§14.2)** — the shorthand is expanded from the rule's declared text (tokens classified by shape, so order does not matter) and resets the components it omits; `background-repeat` and `background-position` no longer pass AngleSharp's literal `"initial"` and tuple form `"(initial, 50%)"` through to the painter, which read as "no repeat" and "position 0" respectively (`Parser`, `DrawCommandExtensions`)
 - **`min-width` / `max-width` on in-flow blocks (§10.4)** — only the absolutely-positioned path clamped, so neither property had any effect on a normal block; a box the clamp gives a known width to now centres under auto margins like an explicitly-sized one (`BoxEngine`)
 - **Replaced-element sizing (§10.3.2 / §10.6.2)** — a CSS `width`/`height` on an inline `<img>` is honoured (the inline path read only the intrinsic pixel size), and HTML's `width`/`height` content attributes are treated as presentational hints for those properties rather than as the intrinsic size — reading them as intrinsic dropped percentages outright and mixed axes, so `width="100%" height="50"` on a 1×1 image derived a height of 39200px (`BoxEngine`, `Parser`)
 - **Anonymous table boxes** — a synthesized box borrows its originating element's style object, so a parent's non-inherited `position: absolute` or `float` read back as its own and took it out of flow; a table's intrinsic width came out zero because its rows are neither block-level nor inline. Both are fixed, so an anonymous table inside a float or an abs-pos box now shrink-wraps and lays its cells out side by side (`LayoutNode`, `IntrinsicSizer`, `BoxEngine`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.13] - 2026-08-05 (current)
+## [0.0.14] - 2026-08-06 (current)
+
+CSS 2.1 conformance pass: **+1000 upstream reftests**. The WPT `css/CSS2` suite goes from
+**2554/6266 (40.8%)** to **3554/6266 (56.7%)**, with no directory regressing. The largest
+movers are `selectors` 93 → 495, `normal-flow` 183 → 369, `margin-padding-clear` 388 → 527,
+`positioning` 203 → 282 and `borders` 296 → 358.
+
+### Added
+
+- **`::first-letter` as a real inline box (§5.12.1)** — the pseudo-element is generated during parsing instead of being re-drawn at paint time, so it contributes its font metrics, `line-height` and width to the line box and paints every property (background, border, margins, …) through the ordinary inline path. The old paint-time version supported only `color` / `font-size` / `font-weight` and never affected layout. Upstream `css/CSS2/selectors`: 93/545 → 495/545 (`Parser`, `Drawer`)
+- **Static position for out-of-flow boxes (§10.3.7 / §10.6.4)** — with `left` / `top` auto, an absolutely positioned box is placed where it would have been in normal flow: the flow pass records the position each out-of-flow child passes over, and one inside an inline run rides along on the line as a zero-sized marker (so it also no longer splits that line in two). Previously such a box was pinned to its containing block's origin (`BoxEngine`, `LayoutNode`)
+- **Text flows around floats line by line (§9.5)** — each line box gets the band the floats leave at its own vertical position, wrapping is measured per line, and the bands are recorded on the text node so painting breaks the lines exactly where layout did. Rule 7 is implemented too: a line too narrow for its first word or atomic box shifts down past the float instead of overflowing (`BoxEngine`, `TextMeasure`, `Drawer`)
+- **Conformance guards** — the curated CSS 2.1 reftest gate grows from 22 to 29 entries, promoting upstream tests for each fix below (`css21-manifest`)
+
+### Fixed
+
+- **`font-size` compounding (§15.7)** — `font-size` computes to a length and descendants inherit *that*; the engine re-resolved the inherited specified value (`2em`) at every level, doubling the size again each time. A four-deep subtree under one such rule reached 512px. Each element's own cascaded declaration (inline style, then author/UA rules by `!important`, specificity and source order, including the `font` shorthand) is now resolved once against the parent's computed size (`Parser`, `DrawCommandExtensions`, `LayoutNode`)
+- **Pixel snapping for square backgrounds and borders** — a box landing on a fractional coordinate painted a half-covered anti-aliased fringe row, while replaced content in the same place paints whole pixels. Square fills now snap like a browser; rounded corners keep anti-aliasing (`Drawer`)
+- **Explicit zero sizes** — `width: 0` / `height: 0` were read as "no size specified" (layout tested `GetWidth() > 0`), so a zero-width box filled its container and a zero-height box grew to its content (`BoxEngine`, `DrawCommandExtensions`)
+- **Invalid negative lengths** — a negative `width`, `height`, `min-`/`max-` pair or `border-width` is invalid, so the declaration is dropped and the property keeps its initial value; `border-top-width: -1px` beside a visible `border-top-style` now paints the initial `medium` (`DrawCommandExtensions`)
+- **Root-relative URL resolution** — `Uri.TryCreate(…, UriKind.Absolute)` accepts `/fonts/ahem.css` as an implicit `file:` URI on Unix, so every root-relative stylesheet, image and form action was handed to the HTTP client unresolved. All resolution goes through a shared `UrlUtils` that treats only a real scheme as absolute (`UrlUtils` and all callers)
+- **CDATA-wrapped inline scripts** — XHTML wraps inline scripts in `<![CDATA[ … ]]>`; those characters are not JavaScript, so the script failed to parse on its first token and nothing it defined existed (`Parser`)
+- **Restored §9.7 / §10.3.2 / §9.5.1 layout work** that had been reverted while its unit tests stayed in the tree: float and abs-pos blockification, replaced-box intrinsic sizing, `position: fixed` painting, inline-block background/border painting, and a float joining the current line box
+
+## [0.0.13] - 2026-08-05
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [0.0.14] - 2026-08-06 (current)
 
-CSS 2.1 conformance pass: **+1000 upstream reftests**. The WPT `css/CSS2` suite goes from
-**2554/6266 (40.8%)** to **3554/6266 (56.7%)**, with no directory regressing. The largest
-movers are `selectors` 93 → 495, `normal-flow` 183 → 369, `margin-padding-clear` 388 → 527,
-`positioning` 203 → 282 and `borders` 296 → 358.
+CSS 2.1 conformance pass: **+1258 upstream reftests**. The WPT `css/CSS2` suite goes from
+**2554/6266 (40.8%)** to **3812/6266 (60.8%)**. The largest movers are `selectors` 93 → 495,
+`normal-flow` 183 → 480, `margin-padding-clear` 388 → 528, `positioning` 203 → 299,
+`borders` 296 → 370, `linebox` 82 → 117, `tables` 39 → 72, `backgrounds` 136 → 169,
+`syntax` 180 → 210, `generated-content` 99 → 129 and `floats-clear` 42 → 72. One directory
+regressed: `abspos` 7 → 5, both cases styling the root element itself as a fixed-position
+table.
 
 ### Added
 
+- **Stylesheet character encoding (§4.4)** — a stylesheet is decoded by its byte-order mark, then an `@charset` rule, then the HTTP `Content-Type` charset, then the linking element's `charset` attribute, then the referring document's or importing sheet's encoding, then UTF-8; the encoding a sheet resolves to becomes the referrer charset for what it imports. Legacy code pages (Shift_JIS, windows-125x, koi8-r, iso-8859-x) are registered via `System.Text.Encoding.CodePages`, which .NET Core does not ship in the shared framework (`Parser`)
 - **`::first-letter` as a real inline box (§5.12.1)** — the pseudo-element is generated during parsing instead of being re-drawn at paint time, so it contributes its font metrics, `line-height` and width to the line box and paints every property (background, border, margins, …) through the ordinary inline path. The old paint-time version supported only `color` / `font-size` / `font-weight` and never affected layout. Upstream `css/CSS2/selectors`: 93/545 → 495/545 (`Parser`, `Drawer`)
 - **Static position for out-of-flow boxes (§10.3.7 / §10.6.4)** — with `left` / `top` auto, an absolutely positioned box is placed where it would have been in normal flow: the flow pass records the position each out-of-flow child passes over, and one inside an inline run rides along on the line as a zero-sized marker (so it also no longer splits that line in two). Previously such a box was pinned to its containing block's origin (`BoxEngine`, `LayoutNode`)
 - **Text flows around floats line by line (§9.5)** — each line box gets the band the floats leave at its own vertical position, wrapping is measured per line, and the bands are recorded on the text node so painting breaks the lines exactly where layout did. Rule 7 is implemented too: a line too narrow for its first word or atomic box shifts down past the float instead of overflowing (`BoxEngine`, `TextMeasure`, `Drawer`)
@@ -23,7 +27,17 @@ movers are `selectors` 93 → 495, `normal-flow` 183 → 369, `margin-padding-cl
 - **Explicit zero sizes** — `width: 0` / `height: 0` were read as "no size specified" (layout tested `GetWidth() > 0`), so a zero-width box filled its container and a zero-height box grew to its content (`BoxEngine`, `DrawCommandExtensions`)
 - **Invalid negative lengths** — a negative `width`, `height`, `min-`/`max-` pair or `border-width` is invalid, so the declaration is dropped and the property keeps its initial value; `border-top-width: -1px` beside a visible `border-top-style` now paints the initial `medium` (`DrawCommandExtensions`)
 - **Root-relative URL resolution** — `Uri.TryCreate(…, UriKind.Absolute)` accepts `/fonts/ahem.css` as an implicit `file:` URI on Unix, so every root-relative stylesheet, image and form action was handed to the HTTP client unresolved. All resolution goes through a shared `UrlUtils` that treats only a real scheme as absolute (`UrlUtils` and all callers)
-- **CDATA-wrapped inline scripts** — XHTML wraps inline scripts in `<![CDATA[ … ]]>`; those characters are not JavaScript, so the script failed to parse on its first token and nothing it defined existed (`Parser`)
+- **`min-width` / `max-width` on in-flow blocks (§10.4)** — only the absolutely-positioned path clamped, so neither property had any effect on a normal block; a box the clamp gives a known width to now centres under auto margins like an explicitly-sized one (`BoxEngine`)
+- **Replaced-element sizing (§10.3.2 / §10.6.2)** — a CSS `width`/`height` on an inline `<img>` is honoured (the inline path read only the intrinsic pixel size), and HTML's `width`/`height` content attributes are treated as presentational hints for those properties rather than as the intrinsic size — reading them as intrinsic dropped percentages outright and mixed axes, so `width="100%" height="50"` on a 1×1 image derived a height of 39200px (`BoxEngine`, `Parser`)
+- **Anonymous table boxes** — a synthesized box borrows its originating element's style object, so a parent's non-inherited `position: absolute` or `float` read back as its own and took it out of flow; a table's intrinsic width came out zero because its rows are neither block-level nor inline. Both are fixed, so an anonymous table inside a float or an abs-pos box now shrink-wraps and lays its cells out side by side (`LayoutNode`, `IntrinsicSizer`, `BoxEngine`)
+- **Attributes** — every authored attribute reaches the layout node, so attribute selectors, `getAttribute` and `attr()` in `content` see what the markup declared; only `data-*` and a per-tag whitelist used to survive (`Parser`)
+- **`line-height: 0`** — text measurement used 0 as the sentinel for "unspecified" and silently substituted the 1.4em default (`TextMeasure`)
+- **`letter-spacing` / `word-spacing` in layout** — measured with the plain font metrics while being painted with the spacing applied, so the box reserved for the text was too narrow and following inline boxes sat in the wrong place (`TextMeasure`, `BoxEngine`)
+- **Preformatted newlines in an inline run (§16.6)** — a newline under `pre` / `pre-wrap` / `pre-line` is a forced break; an inline run measured the whole string as one item, so a preformatted `<span>` drew its lines on top of each other (`BoxEngine`)
+- **Inline fragments** — an inline box broken over several line boxes now has one fragment per line, so its background and text paint on each rather than only the last (`LayoutNode`, `BoxEngine`, `Drawer`)
+- **Whitespace under `pre`** — trimming an element's text implements §16.6.1's "remove the spaces at the start and end of a line", so it must not apply where white-space is preserved: a cell holding a single space is a space wide, not zero (`Parser`)
+- **CDATA-wrapped inline scripts** — XHTML wraps inline scripts in `<![CDATA[ … ]]>`; those characters are not JavaScript, so the script failed to parse on its first token (`Parser`)
+- **Crash parsing a lone quote in `content`** — the value both starts and ends with a quote, and stripping one off each end asked for a negative-length slice (`Parser`)
 - **Restored §9.7 / §10.3.2 / §9.5.1 layout work** that had been reverted while its unit tests stayed in the tree: float and abs-pos blockification, replaced-box intrinsic sizing, `position: fixed` painting, inline-block background/border painting, and a float joining the current line box
 
 ## [0.0.13] - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.14] - 2026-08-06 (current)
+## [0.0.15] - 2026-08-07 (current)
+
+Second CSS 2.1 conformance pass, on inline formatting: **+125 upstream reftests**. The WPT
+`css/CSS2` suite goes from **3917/6266 (62.5%)** to **4042/6266 (64.5%)**. `normal-flow`
+479 → 537, `backgrounds` 184 → 215, `borders` 370 → 379, `css1` 46 → 54, `text` 254 → 260,
+`floats-clear` 72 → 76, `linebox` 117 → 120 and `positioning` 314 → 317. Two directories give
+ground, both for the same reason: nothing paints a border on an inline box yet, so
+`margin-padding-clear` 528 → 526 and `box` 9 → 8 lose the tests that draw one.
+
+### Added
+
+- **Line boxes have a strut (§10.8.1)** — every line box now begins with the zero-width inline box its block container implies, so a line holding only a 96px image is still at least as tall as the text that would have sat on its baseline. Three details the naive version gets wrong are handled: the strut's reach *below* the baseline is negative when `line-height` is smaller than the font's ascent+descent (clamping it to zero stretched a `line-height: 10px` line back out); §9.4.2 keeps a line with no content, no forced break and no in-flow boxes at zero height, so a stray run of collapsible whitespace is not resurrected; and under `line-height: normal` the strut uses the font's own ascent+descent rather than the engine's more generous 1.4em, which would otherwise poke out above a 16px image (`BoxEngine`, `DrawCommandExtensions`)
+- **Conformance guards** — the curated CSS 2.1 gate grows from 40 to 52 entries, promoting an upstream reftest for each fix below; `--geom` also reports the resolved background properties (`css21-manifest`, `RefTestRunner`)
+
+### Fixed
+
+- **Inline replaced boxes reserve their edges (§8.4)** — an `<img>` on a line was measured at the bitmap's used size alone, so `img { padding-right: 20px }` advanced the line by nothing and the next image sat flush against it. The item is now built from the margin box, the node's own box starts inside its edges, and the image paints its background/border/outline like any other replaced box. This lands on two shared reftest references that the whole `height` / `min-height` / `max-height` family matches against, which is most of `normal-flow`'s gain (`BoxEngine`, `Drawer`)
+- **`auto` margins on inline boxes (§10.3.1 / §10.3.2 / §10.6.2)** — `auto` has a used value of 0 on an inline box, replaced or not. The engine read it as the block-level "take the free space in the containing block" rule, so once inline margins were honoured an `img { margin-top: auto; margin-bottom: auto }` grew a 96px line box and left the bitmap floating in the middle of it (`BoxEngine`, `DrawCommandExtensions`)
+- **Inline boxes reserve their horizontal margins and padding (§8.4)** — a non-replaced inline box's horizontal margins and padding take part in layout; only its vertical edges are ignored, and those only for the line box's height. The background is painted over the padding box so it covers what the line reserved. An inline box broken around a block child (§9.2.1.1) gets no edges rather than a duplicate set on every fragment, and neither does one under `direction: rtl`, whose edges belong to fragments a strictly left-to-right line cannot place (`BoxEngine`, `Drawer`, `DrawCommandExtensions`)
+- **`letter-spacing` / `word-spacing` units (§16.4 / §16.5)** — both take any length, but only `px` and `em` were parsed by hand; `72pt`, `6pc` and `2.54cm` computed to 0, so every non-px spacing test drew its text unspaced (`DrawCommandExtensions`)
+- **CSS colour keywords reaching the painter** — `SKColor.TryParse` understands hex only, so a keyword arriving through the engine's own cascade — which is how every colour pulled out of a shorthand looks — silently fell through to whatever AngleSharp had computed, normally a lower-specificity rule's colour. Keywords now resolve through AngleSharp's colour table (`DrawCommandExtensions`)
+- **`background` shorthands AngleSharp drops (§14.2)** — AngleSharp.Css refuses a `background` whose position is a bare keyword and discards the whole declaration, so `background: bottom green` and `background: red url(x.png) right repeat-y` left the element with a weaker rule's background. The shorthand is read back out of the stylesheet source for rules where AngleSharp kept nothing of the background family, so a longhand written after the shorthand still wins. The source scan follows §4.2 error handling: backslash escapes and strings are not block delimiters, a declaration containing a block is malformed and dropped whole, and a selector that declares a background more than once is left alone because source order between them is not recoverable from a CSSOM rule (`Parser`)
+
+### Known limitations
+
+- An inline box's **borders** are still not painted. Reserving room for them in the line and stroking them was measured against the suite and came out flat: it fixes the tests that expect a visible inline border and breaks the same number of block-in-inline ones, which need one fragment box per piece before the edges can land in the right places.
+
+## [0.0.14] - 2026-08-06
 
 CSS 2.1 conformance pass: **+1363 upstream reftests**. The WPT `css/CSS2` suite goes from
 **2554/6266 (40.8%)** to **3917/6266 (62.5%)**. The largest movers are `selectors` 93 → 495,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
+  </ItemGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,0 @@
-<Project>
-  <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
-  </ItemGroup>
-</Project>

--- a/Lite.Conformance/Css21/RefTestRunner.cs
+++ b/Lite.Conformance/Css21/RefTestRunner.cs
@@ -229,7 +229,9 @@ internal static class RefTestRunner
                         ' clientW=' + e.clientWidth + ' clientH=' + e.clientHeight +
                         ' fontSize=' + cs.fontSize + ' borderTop=' + cs.borderTopWidth +
                         ' width=' + cs.width + ' marginTop=' + cs.marginTop +
-                        ' lineHeight=' + cs.lineHeight);
+                        ' lineHeight=' + cs.lineHeight +
+                        ' bgColor=' + cs.backgroundColor + ' bgImage=' + cs.backgroundImage +
+                        ' bgPos=' + cs.backgroundPosition + ' bgRepeat=' + cs.backgroundRepeat);
                     for (var c=e.firstElementChild; c; c=c.nextElementSibling) {{
                         console.log('[GEOM]   child ' + c.tagName +
                             ' offsetW=' + c.offsetWidth + ' offsetH=' + c.offsetHeight +

--- a/Lite.Conformance/Css21/css21-manifest.txt
+++ b/Lite.Conformance/Css21/css21-manifest.txt
@@ -159,3 +159,18 @@ css/CSS2/normal-flow/inline-replaced-height-001.xht
 #      against an inline image's line; line-height-127 checks the line box of an empty inline. ----
 css/CSS2/backgrounds/background-position-applies-to-001.xht
 css/CSS2/linebox/line-height-127.xht
+
+# ---- §8.4: the horizontal margins and padding of a NON-replaced inline box are laid out (its
+#      vertical edges are not); §16.4/§16.5 letter-/word-spacing take any length unit; and a CSS
+#      colour KEYWORD reaching the painter through StyleOverrides has to parse — SKColor.TryParse
+#      only understands hex, so `background: red url(...)` used to fall back to whatever a
+#      lower-specificity rule had set. -imrgn-l/-ipadn-l need the inline edges AND the shorthand
+#      below; letter-spacing-019 is the px test's `72pt` twin. ----
+css/CSS2/css1/c5504-imrgn-l-000.xht
+css/CSS2/css1/c5509-ipadn-l-000.xht
+css/CSS2/text/letter-spacing-019.xht
+
+# ---- §14.2: AngleSharp.Css drops a whole `background` declaration whose position is a bare
+#      keyword, so the shorthand is re-read from the stylesheet source for rules where it kept
+#      nothing of the family. background-position-004 writes `background: bottom green`. ----
+css/CSS2/backgrounds/background-position-004.xht

--- a/Lite.Conformance/Css21/css21-manifest.txt
+++ b/Lite.Conformance/Css21/css21-manifest.txt
@@ -141,3 +141,10 @@ css/CSS2/backgrounds/background-029.xht
 #      -168 needs the box generated inside an inline parent to be an inline-table. ----
 css/CSS2/tables/table-anonymous-objects-059.xht
 css/CSS2/tables/table-anonymous-objects-012.xht
+
+# ---- §8.4: an inline REPLACED box's margin/border/padding take part in layout on both axes.
+#      Both of these hinge on the shared references: height-006-ref places two 96x96 images with
+#      `img + img { padding-left: 4px }`, min-height-067-ref two with `img { padding-right: 20px }`,
+#      and reserving only the content size collapsed those gaps to nothing. ----
+css/CSS2/normal-flow/min-height-006.xht
+css/CSS2/normal-flow/min-height-067.xht

--- a/Lite.Conformance/Css21/css21-manifest.txt
+++ b/Lite.Conformance/Css21/css21-manifest.txt
@@ -152,3 +152,10 @@ css/CSS2/normal-flow/min-height-067.xht
 # ---- §10.3.2 / §10.6.2: 'auto' margins on an inline replaced box have a used value of 0, not
 #      the block-level "centre in the containing block" rule. ----
 css/CSS2/normal-flow/inline-replaced-height-001.xht
+
+# ---- §10.8.1's strut: every line box starts with a zero-width inline box carrying the block
+#      container's font and line-height, so a line holding only an image is still at least as tall
+#      as the text that would have sat on its baseline. -applies-to-001 places a background swatch
+#      against an inline image's line; line-height-127 checks the line box of an empty inline. ----
+css/CSS2/backgrounds/background-position-applies-to-001.xht
+css/CSS2/linebox/line-height-127.xht

--- a/Lite.Conformance/Css21/css21-manifest.txt
+++ b/Lite.Conformance/Css21/css21-manifest.txt
@@ -104,3 +104,23 @@ css/CSS2/floats/floats-wrap-bfc-with-margin-001.html
 # ---- §10.3.7 / §10.6.4: with left/top auto an absolutely positioned box takes its static
 #      position — where it would have been in normal flow — not its containing block's origin. ----
 css/CSS2/abspos/hypothetical-box-dynamic.html
+
+# ---- §4.4: a stylesheet is decoded by its BOM, then @charset, then the HTTP charset, then the
+#      linking element and the referring document. Decoding everything as UTF-8 both mangled a
+#      sheet in a legacy encoding and left a U+FEFF breaking the first selector of one with a
+#      BOM. (The harness serves WPT's "<file>.headers" sidecars so the HTTP charset is visible.)
+css/CSS2/syntax/at-charset-001.xht
+css/CSS2/syntax/at-charset-003.xht
+
+# ---- §10.4: min-width / max-width clamp an in-flow block, not just an absolutely positioned one.
+css/CSS2/normal-flow/max-width-001.xht
+
+# ---- §10.3.2: a CSS width/height sizes a replaced element, and HTML's width/height attributes
+#      are presentational hints for those properties rather than the intrinsic size.
+css/CSS2/backgrounds/background-001.xht
+
+# ---- attr() in 'content' needs the authored attribute to reach the layout node.
+css/CSS2/generated-content/content-002.xht
+
+# ---- 'line-height: 0' collapses the line box; 0 was being read as "unspecified".
+css/CSS2/linebox/line-height-002.xht

--- a/Lite.Conformance/Css21/css21-manifest.txt
+++ b/Lite.Conformance/Css21/css21-manifest.txt
@@ -76,3 +76,31 @@ css21/replaced-block-size.html | css21/replaced-block-size-ref.html
 css21/fixed-position-paint.html | css21/fixed-position-paint-ref.html
 
 # ---- Phase 3 additions (full anonymous-box splitting, z-index:auto subtlety...) ----
+
+# ---- §5.12.1: ::first-letter is a real inline box, so its font metrics and 'line-height' size
+#      the line box it sits on. Styling it at paint time (re-drawing the first characters larger)
+#      left the line box sized for the parent's font. Upstream css/CSS2/selectors 93 -> 495. ----
+css/CSS2/selectors/first-letter-punctuation-001.xht
+css/CSS2/selectors/first-letter-nested-005.xht
+
+# ---- A background must paint whole device pixels, like the replaced content the suite's own
+#      references use in its place. Anti-aliasing a box that lands on a fractional y left a
+#      half-covered fringe row, which alone blew the pixel budget in ~370 normal-flow tests. ----
+css/CSS2/normal-flow/width-050.xht
+
+# ---- §15.7: 'font-size' computes to a length and descendants inherit THAT. Re-resolving the
+#      inherited specified value ("2em") at every level doubled the size again each time — the
+#      Gecko-imported anonymous-table tests reached 1024px and painted glyphs across the page. ----
+css/CSS2/tables/table-anonymous-objects-015.xht
+
+# ---- A negative 'border-width' is invalid, so the side falls back to the initial 'medium'
+#      wherever it still has a visible style. ----
+css/CSS2/borders/border-top-width-001.xht
+
+# ---- §9.5 rule 7: a line box too narrow for its content shifts down past the float instead of
+#      overflowing it, and lines below the float get the full width back. ----
+css/CSS2/floats/floats-wrap-bfc-with-margin-001.html
+
+# ---- §10.3.7 / §10.6.4: with left/top auto an absolutely positioned box takes its static
+#      position — where it would have been in normal flow — not its containing block's origin. ----
+css/CSS2/abspos/hypothetical-box-dynamic.html

--- a/Lite.Conformance/Css21/css21-manifest.txt
+++ b/Lite.Conformance/Css21/css21-manifest.txt
@@ -124,3 +124,13 @@ css/CSS2/generated-content/content-002.xht
 
 # ---- 'line-height: 0' collapses the line box; 0 was being read as "unspecified".
 css/CSS2/linebox/line-height-002.xht
+
+# ---- §10.3.7 / §10.6.4: with the offsets and the size all given, an auto margin takes the space
+#      left over and two of them split it. -002 also covers rule 1's RTL static position. ----
+css/CSS2/positioning/absolute-non-replaced-width-002.xht
+css/CSS2/positioning/absolute-non-replaced-width-003.xht
+
+# ---- §14.2: the 'background' shorthand is expanded from the declared text and resets what it
+#      omits; an unset longhand reported as the literal "initial" is the property's initial value,
+#      and the position pair arrives as a tuple, "(initial, 50%)". ----
+css/CSS2/backgrounds/background-029.xht

--- a/Lite.Conformance/Css21/css21-manifest.txt
+++ b/Lite.Conformance/Css21/css21-manifest.txt
@@ -148,3 +148,7 @@ css/CSS2/tables/table-anonymous-objects-012.xht
 #      and reserving only the content size collapsed those gaps to nothing. ----
 css/CSS2/normal-flow/min-height-006.xht
 css/CSS2/normal-flow/min-height-067.xht
+
+# ---- §10.3.2 / §10.6.2: 'auto' margins on an inline replaced box have a used value of 0, not
+#      the block-level "centre in the containing block" rule. ----
+css/CSS2/normal-flow/inline-replaced-height-001.xht

--- a/Lite.Conformance/Css21/css21-manifest.txt
+++ b/Lite.Conformance/Css21/css21-manifest.txt
@@ -174,3 +174,13 @@ css/CSS2/text/letter-spacing-019.xht
 #      keyword, so the shorthand is re-read from the stylesheet source for rules where it kept
 #      nothing of the family. background-position-004 writes `background: bottom green`. ----
 css/CSS2/backgrounds/background-position-004.xht
+
+# ---- §4.2 error handling as the raw-`background` source scan has to see it: a declaration
+#      containing a block is malformed and dropped whole (core-syntax-001), and `\{` is an escaped
+#      character rather than a block start (escapes-002). ----
+css/CSS2/syntax/core-syntax-001.xht
+css/CSS2/syntax/escapes-002.xht
+
+# ---- §9.4.2's bidi box model: under 'direction: rtl' an inline box's edges belong to its right
+#      and left fragments, which a strictly left-to-right line cannot place. ----
+css/CSS2/box/rtl-span-only.xht

--- a/Lite.Conformance/Css21/css21-manifest.txt
+++ b/Lite.Conformance/Css21/css21-manifest.txt
@@ -134,3 +134,10 @@ css/CSS2/positioning/absolute-non-replaced-width-003.xht
 #      omits; an unset longhand reported as the literal "initial" is the property's initial value,
 #      and the position pair arrives as a tuple, "(initial, 50%)". ----
 css/CSS2/backgrounds/background-029.xht
+
+# ---- Anonymous table boxes (§17.2.1). -059 needs an absolutely positioned <table> to lay out as
+#      a table and the cellspacing/cellpadding attributes to reach the cells; -012 needs the
+#      generated boxes rebuilt after a display change (the test toggles a cell to 'none' and back);
+#      -168 needs the box generated inside an inline parent to be an inline-table. ----
+css/CSS2/tables/table-anonymous-objects-059.xht
+css/CSS2/tables/table-anonymous-objects-012.xht

--- a/Lite.Conformance/Harness/ConformanceServer.cs
+++ b/Lite.Conformance/Harness/ConformanceServer.cs
@@ -39,6 +39,32 @@ internal static class ConformanceServer
         contentTypes.Mappings[".xht"] = "text/html";
         contentTypes.Mappings[".xhtml"] = "text/html";
 
+        // WPT convention: a sibling "<file>.headers" supplies the response headers for <file>.
+        // Several CSS 2.1 encoding tests declare the stylesheet's charset only that way, so
+        // without this the engine never sees the header it is being tested on.
+        app.Use(async (ctx, next) =>
+        {
+            var path = ctx.Request.Path.Value ?? "";
+            var file = ResolveFile(path);
+            if (file is not null && File.Exists(file + ".headers"))
+            {
+                foreach (var line in await File.ReadAllLinesAsync(file + ".headers"))
+                {
+                    var colon = line.IndexOf(':');
+                    if (colon <= 0) continue;
+                    var name = line[..colon].Trim();
+                    var value = line[(colon + 1)..].Trim();
+                    if (name.Equals("Content-Type", StringComparison.OrdinalIgnoreCase))
+                        ctx.Response.ContentType = value;
+                    else
+                        ctx.Response.Headers[name] = value;
+                }
+                await ctx.Response.SendFileAsync(file);
+                return;
+            }
+            await next();
+        });
+
         // WPT .any.js tests are addressed as <name>.any.html — generate the standard wrapper.
         app.Use(async (ctx, next) =>
         {

--- a/Lite.Tests/CascadeTests.cs
+++ b/Lite.Tests/CascadeTests.cs
@@ -152,4 +152,45 @@ public static class CascadeTests
         Equal("0%", c.GetBackgroundPosition().X);
         Equal("0%", c.GetBackgroundPosition().Y);
     }
+
+    [Test]
+    public static void BackgroundShorthand_WithKeywordPositionSurvivesAngleSharpDroppingIt()
+    {
+        // AngleSharp.Css refuses a `background` whose position is a bare keyword and drops the
+        // whole declaration, leaving the element with a lower-specificity rule's colour. The
+        // shorthand is read back out of the stylesheet source for exactly those rules — but only
+        // when AngleSharp kept nothing from the background family, so a longhand written AFTER the
+        // shorthand still wins (§14.2 ordering).
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>" +
+            "div { background: yellow; }" +
+            "#one { background: red url('x.png') right repeat-y; }" +
+            "#two { background: bottom green; }" +
+            "#three { background: repeat-x; background-image: url('y.png'); }" +
+            "</style></head><body>" +
+            "<div id='one'></div><div id='two'></div><div id='three'></div>" +
+            "</body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+
+        LayoutNode? F(LayoutNode n, string id) =>
+            n.Id == id ? n : n.Children.Select(c => F(c, id)).FirstOrDefault(r => r != null);
+
+        var one = F(page.Root, "one")!;
+        Console.WriteLine($"[dbg] one style bg: '{one.Style.GetPropertyValueSafe("background-color")}'");
+        True(one.GetBackgroundColor().Red > 100 && one.GetBackgroundColor().Green < 100,
+            $"`background: red url(...) right repeat-y` should win over `div {{ background: yellow }}`, " +
+            $"got {one.GetBackgroundColor()}");
+        Equal("repeat-y", one.GetBackgroundRepeat());
+        Equal("right", one.GetBackgroundPosition().X);
+
+        var two = F(page.Root, "two")!;
+        True(two.GetBackgroundColor().Green > 100 && two.GetBackgroundColor().Red < 100,
+            $"`background: bottom green` should set green, got {two.GetBackgroundColor()}");
+
+        // AngleSharp parses this one, so its longhand ordering must be left alone: the explicit
+        // background-image comes after the shorthand and survives it.
+        var three = F(page.Root, "three")!;
+        True(three.GetBackgroundImage().Contains("y.png", StringComparison.Ordinal),
+            $"a longhand after the shorthand must win, got '{three.GetBackgroundImage()}'");
+    }
 }

--- a/Lite.Tests/CascadeTests.cs
+++ b/Lite.Tests/CascadeTests.cs
@@ -193,4 +193,36 @@ public static class CascadeTests
         True(three.GetBackgroundImage().Contains("y.png", StringComparison.Ordinal),
             $"a longhand after the shorthand must win, got '{three.GetBackgroundImage()}'");
     }
+
+    [Test]
+    public static void BackgroundRescue_IgnoresMalformedAndAmbiguousSource()
+    {
+        // The source scan is a mini-parser, so it has to make the same calls CSS 2.1 §4.2 does:
+        //  * a declaration containing a BLOCK is malformed and dropped whole, so the `background`
+        //    nested inside one is not a declaration of the outer rule;
+        //  * `\{` is an escaped character, not the start of a block, so the rule that follows is
+        //    swallowed by the malformed selector rather than standing on its own;
+        //  * a selector that declares a background more than once is left to AngleSharp — source
+        //    order between them is not recoverable from a CSSOM rule on its own.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>" +
+            "#a { background: green; }" +
+            "#a { nested { background: red; }: not-a-declaration; }" +
+            "#b { background: green; }" +
+            "#b \\{ background: red; \\}" +
+            "#b { background: red; }" +
+            "</style></head><body><div id='a'></div><div id='b'></div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+
+        LayoutNode? F(LayoutNode n, string id) =>
+            n.Id == id ? n : n.Children.Select(c => F(c, id)).FirstOrDefault(r => r != null);
+
+        foreach (var id in new[] { "a", "b" })
+        {
+            var node = F(page.Root, id)!;
+            var bg = node.GetBackgroundColor();
+            True(bg.Green > 100 && bg.Red < 100,
+                $"#{id} should keep its green background — the red one is malformed, got {bg}");
+        }
+    }
 }

--- a/Lite.Tests/CascadeTests.cs
+++ b/Lite.Tests/CascadeTests.cs
@@ -1,4 +1,5 @@
 using Lite;
+using Lite.Extensions;
 using Lite.Layout;
 using Lite.Models;
 using Lite.Scripting;
@@ -122,5 +123,33 @@ public static class CascadeTests
         True(SelectorEngine.Matches(a, ":link"), "anchor with href should match :link");
         True(!SelectorEngine.Matches(plain, ":link"), "anchor without href should not match :link");
         True(!SelectorEngine.Matches(a, ":visited"), ":visited should never match (no history)");
+    }
+
+    [Test]
+    public static void BackgroundShorthand_ExpandsInAnyOrderAndResetsWhatItOmits()
+    {
+        // The shorthand is expanded from the declared text, classifying tokens by shape so their
+        // order does not matter, and resets the components it does not mention — AngleSharp
+        // reports an unset longhand of a shorthand as the literal "initial", which the painter
+        // then read as "no repeat at all".
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>" +
+            "#b { background: green url('x.png') repeat-x; }" +
+            "#c { background: green; }" +
+            "</style></head><body><div id='b'></div><div id='c'></div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+
+        LayoutNode? F(LayoutNode n, string id) => n.Id == id ? n : n.Children.Select(c => F(c, id)).FirstOrDefault(r => r != null);
+        var b = F(page.Root, "b")!;
+        var c = F(page.Root, "c")!;
+
+        Equal("repeat-x", b.GetBackgroundRepeat());
+        True(b.GetBackgroundColor().Green > 100 && b.GetBackgroundColor().Red < 100,
+            $"the colour survives alongside an image and a repeat, got {b.GetBackgroundColor()}");
+
+        // Nothing else named, so the omitted components take their initial values.
+        Equal("repeat", c.GetBackgroundRepeat());
+        Equal("0%", c.GetBackgroundPosition().X);
+        Equal("0%", c.GetBackgroundPosition().Y);
     }
 }

--- a/Lite.Tests/CssWideKeywordTests.cs
+++ b/Lite.Tests/CssWideKeywordTests.cs
@@ -73,4 +73,29 @@ public static class CssWideKeywordTests
         b.StyleOverrides["list-style"] = "square url(\"http://x/dot.gif\") inside";
         Equal("http://x/dot.gif", b.GetListStyleImage());
     }
+
+    [Test]
+    public static void StylesheetEncoding_FollowsBomThenAtCharsetThenHttp()
+    {
+        // CSS 2.1 §4.4. Decoding every sheet as UTF-8 both mangles one in a legacy encoding and
+        // leaves the U+FEFF of a BOM at the front of the text, which breaks its first selector.
+        var utf8 = System.Text.Encoding.UTF8;
+
+        var bom = utf8.GetPreamble().Concat(utf8.GetBytes("#a { color: green }")).ToArray();
+        Equal("#a { color: green }", Parser.DecodeCss(bom, "iso-8859-5", null, null, out var used1));
+        Equal("utf-8", used1);
+
+        // @charset outranks the HTTP header, and a legacy code page decodes correctly.
+        var declared = "@charset \"shift-JIS\";\n.\u5e73\u548c { color: green }";
+        var sjis = System.Text.Encoding.GetEncoding("shift_jis").GetBytes(declared);
+        True(Parser.DecodeCss(sjis, "utf-8", null, null, out _).Contains("\u5e73\u548c"),
+            "an @charset-declared encoding must win over the HTTP charset");
+
+        // With neither, the linking element's charset attribute is consulted before the fallback.
+        var plain = System.Text.Encoding.GetEncoding("shift_jis").GetBytes(".\u5e73\u548c { color: green }");
+        True(Parser.DecodeCss(plain, null, "shift-JIS", null, out _).Contains("\u5e73\u548c"),
+            "the link element's charset attribute must be honoured");
+        True(Parser.DecodeCss(plain, null, null, "shift-JIS", out _).Contains("\u5e73\u548c"),
+            "and the referring document's encoding after it");
+    }
 }

--- a/Lite.Tests/DomTests.cs
+++ b/Lite.Tests/DomTests.cs
@@ -477,4 +477,19 @@ public static class DomTests
         Equal("l1", (string?)Val(engine, "firstPass"));
         Equal("l1,l1,l3", (string?)Val(engine, "secondPass"));
     }
+
+    [Test]
+    public static void InlineScript_RunsWhenWrappedInACdataSection()
+    {
+        // XHTML wraps inline scripts in <![CDATA[ ... ]]> to keep the markup well-formed XML.
+        // Those characters are not JavaScript: left in place the script failed to parse on its
+        // first token and nothing it defined ever existed.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><script type=\"text/javascript\">//<![CDATA[\n" +
+            "globalThis.__cdata = 42;\n//]]></script></head><body><p>x</p></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        var engine = page.Engine!;
+        True(Convert.ToInt32(engine.RawEngine.GetValue("__cdata").ToObject()) == 42,
+            "a CDATA-wrapped inline script must run");
+    }
 }

--- a/Lite.Tests/DomTests.cs
+++ b/Lite.Tests/DomTests.cs
@@ -492,4 +492,25 @@ public static class DomTests
         True(Convert.ToInt32(engine.RawEngine.GetValue("__cdata").ToObject()) == 42,
             "a CDATA-wrapped inline script must run");
     }
+
+    [Test]
+    public static void ArbitraryAttributes_AreCapturedForSelectorsAndAttr()
+    {
+        // Only data-* and a per-tag whitelist used to reach the layout node, so an attribute
+        // selector or attr() naming anything else saw nothing at all.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>td:before { content: attr(abbr); }</style></head>" +
+            "<body><table><tr><td id='c' abbr='PASS' axis='x'></td></tr></table></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+
+        var td = FindNodeByTag(page.Root, n => n.Id == "c")!;
+        Equal("PASS", td.Attributes.GetValueOrDefault("abbr"));
+        Equal("x", td.Attributes.GetValueOrDefault("axis"));
+        var before = td.Children.FirstOrDefault(c => c.TagName == "#pseudo-before");
+        True(before != null && before.DisplayText == "PASS",
+            $"content: attr(abbr) should generate \"PASS\", got \"{before?.DisplayText}\"");
+    }
+
+    private static LayoutNode? FindNodeByTag(LayoutNode n, Func<LayoutNode, bool> pred) =>
+        pred(n) ? n : n.Children.Select(c => FindNodeByTag(c, pred)).FirstOrDefault(r => r != null);
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1440,4 +1440,26 @@ public static class LayoutTests
         True(cells.All(c => Math.Abs(c.Box.ContentBox.Top - cells[0].Box.ContentBox.Top) < 0.5f),
             "and they share the row's top");
     }
+
+    [Test]
+    public static void MisparentedCellsInAnInlineBox_GenerateAnInlineTable()
+    {
+        // §17.2.1: "If the box's parent is an inline box, generate an anonymous inline-table box;
+        // otherwise, an anonymous table box." A block-level table inside an inline box broke the
+        // line in two, so cells written between inline text landed on their own line.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><body><div><span id='s'>a" +
+            "<span style='display: table-cell'>b</span><span style='display: table-cell'>c</span>" +
+            "d</span></div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var table = FindNode(page.Root, n => n.TagName == "#anon-table")!;
+        True(table.GetDisplay() == DisplayType.InlineTable,
+            $"the generated table is inline-level inside an inline box, got {table.GetDisplay()}");
+        // Everything stays on one line: the table sits between the two text runs.
+        var s2 = FindNode(page.Root, n => n.Id == "s")!;
+        True(s2.Box.ContentBox.Height < 40f,
+            $"the run stays on one line, got height {s2.Box.ContentBox.Height}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1107,4 +1107,27 @@ public static class LayoutTests
         True(Math.Abs(Fs("own") - 64f) < 0.5f, $"a re-declared 2em does scale again, got {Fs("own")}");
         True(Math.Abs(Fs("sh") - 96f) < 0.5f, $"the 'font' shorthand sets the size (1in), got {Fs("sh")}");
     }
+
+    [Test]
+    public static void NegativeLengths_AreInvalidAndFallBackToTheInitialValue()
+    {
+        // CSS 2.1: a negative 'width'/'height'/'border-width' is invalid, so the declaration is
+        // dropped and the property keeps its initial value. AngleSharp hands the negative length
+        // through, which turned `width: -1px` into a zero-width box and dropped a border whose
+        // side still had a visible style.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>" +
+            "#w { width: -1px; height: 20px; }" +
+            "#b { border-top-style: solid; border-top-width: -1px; height: 20px; }" +
+            "</style></head><body><div id='w'></div><div id='b'></div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var w = FindNode(page.Root, n => n.Id == "w")!;
+        var b = FindNode(page.Root, n => n.Id == "b")!;
+        True(w.Box.ContentBox.Width > 100f,
+            $"an invalid negative width falls back to auto (fills the block), got {w.Box.ContentBox.Width}");
+        True(Math.Abs(b.Box.Border.Top - 3f) < 0.5f,
+            $"an invalid negative border-width falls back to medium (3px), got {b.Box.Border.Top}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1267,4 +1267,44 @@ public static class LayoutTests
         True(z.Box.ContentBox.Height < 1f,
             $"line-height:0 collapses every line box, expected height 0, got {z.Box.ContentBox.Height}");
     }
+
+    [Test]
+    public static void LetterSpacing_WidensTheBoxLayoutReservesForText()
+    {
+        // 'letter-spacing' widens the text the painter draws, so it has to widen the box layout
+        // reserves for it too — measuring without it put every following inline box in the wrong
+        // place. The span here is 3 characters, so it gains 2 gaps of 10px.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>#a { letter-spacing: 10px } " +
+            "span { font-size: 16px }</style></head>" +
+            "<body><div><span id='a'>abc</span><span id='b'>x</span></div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var a = FindNode(page.Root, n => n.Id == "a")!;
+        var b = FindNode(page.Root, n => n.Id == "b")!;
+        True(a.Box.ContentBox.Width > 20f + 20f,
+            $"three letters plus two 10px gaps, got {a.Box.ContentBox.Width}");
+        True(b.Box.ContentBox.Left >= a.Box.ContentBox.Right - 0.5f,
+            $"the next inline box starts after the spaced text, got {b.Box.ContentBox.Left} vs {a.Box.ContentBox.Right}");
+    }
+
+    [Test]
+    public static void InlinePreformattedText_BreaksAtItsNewlines()
+    {
+        // §16.6: under 'white-space: pre' a newline is a forced break. An inline run measured the
+        // whole string as one unbroken item, so a preformatted <span> holding two lines drew them
+        // on top of each other.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>#p { white-space: pre }</style></head>" +
+            "<body><div id='d'><span id='p'>XX\nXX</span></div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var d = FindNode(page.Root, n => n.Id == "d")!;
+        var p = FindNode(page.Root, n => n.Id == "p")!;
+        True(d.Box.ContentBox.Height > p.Box.ContentBox.Height * 1.5f,
+            $"the preformatted newline makes two line boxes, got block height {d.Box.ContentBox.Height} " +
+            $"for a line of {p.Box.ContentBox.Height}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -910,6 +910,29 @@ public static class LayoutTests
     }
 
     [Test]
+    public static void LineBox_IncludesTheStrutOfItsBlockContainer()
+    {
+        // CSS 2.1 §10.8.1: every line box starts with a zero-width inline box carrying the block
+        // container's font and line-height — the "strut". A line holding only a short image is
+        // still at least the strut's height, and the image's baseline sits on the line's.
+        var img = Img(20, 4);
+        var cb = Block(new() { ["width"] = "400px", ["line-height"] = "40px" }, img);
+        LayoutTree(cb);
+        True(Math.Abs(cb.Box.ContentBox.Height - 40f) < 1f,
+            $"a 4px image on a line-height:40px line should still give a 40px line box, " +
+            $"got {cb.Box.ContentBox.Height}");
+
+        // §9.4.2: a run of collapsible whitespace alone is a ZERO-height line box, so the strut
+        // must not resurrect it.
+        var blank = new LayoutNode(null, "#text", "   ", _styleCache.Style);
+        blank.StyleOverrides["display"] = "inline";
+        var empty = Block(new() { ["width"] = "400px", ["line-height"] = "40px" }, blank);
+        LayoutTree(empty);
+        True(empty.Box.ContentBox.Height < 1f,
+            $"a whitespace-only run is a zero-height line box, got {empty.Box.ContentBox.Height}");
+    }
+
+    [Test]
     public static void TextAlignRight_MovesInlineLevelBoxesNotJustText()
     {
         // CSS 2.1 §16.2 aligns the whole LINE BOX. text-align had a single consumer in the text

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1044,4 +1044,43 @@ public static class LayoutTests
         True(Math.Abs(two.Box.ContentBox.Left - 0f) < 0.5f,
             $"the second line clears the 20px float and starts at x=0, got {two.Box.ContentBox.Left}");
     }
+
+    [Test]
+    public static void ExplicitZeroSize_IsNotTreatedAsAuto()
+    {
+        // 'width: 0' / 'height: 0' are used values, not "unspecified". The engine tested for a
+        // specified size with "GetWidth() > 0", so a zero-sized box filled its container's width
+        // and grew to its content's height instead of collapsing.
+        var zero = Block(new() { ["width"] = "0", ["height"] = "0" },
+                         Block(new() { ["height"] = "40px" }));
+        LayoutTree(Block(new() { ["width"] = "200px" }, zero));
+
+        True(Math.Abs(zero.Box.ContentBox.Width) < 0.5f,
+            $"width:0 must stay 0, got {zero.Box.ContentBox.Width}");
+        True(Math.Abs(zero.Box.ContentBox.Height) < 0.5f,
+            $"height:0 must stay 0, got {zero.Box.ContentBox.Height}");
+    }
+
+    [Test]
+    public static void BackgroundOnAFractionalBoundary_PaintsWholePixels()
+    {
+        // A background is snapped to device pixels like replaced content is, so a box whose edges
+        // land on a fraction paints solid rows rather than a half-covered anti-aliased fringe.
+        // Reftests constantly compare a filled box against an image of the same size, and the
+        // fringe alone was enough to blow the pixel budget.
+        var box = Block(new()
+        {
+            ["margin-top"] = "10.4px",
+            ["width"] = "50px",
+            ["height"] = "20px",
+            ["background-color"] = "#000000",
+        });
+        var root = LayoutTree(Block(new() { ["width"] = "200px" }, box));
+
+        using var bmp = Drawer.DrawToBitmap(800, 600, root, new Viewport { ViewportHeight = 600 });
+        var top = (int)MathF.Round(box.Box.PaddingBox.Top);
+        var px = bmp.GetPixel(10, top);
+        True(px.Red == 0 && px.Green == 0 && px.Blue == 0,
+            $"the top row of the background must be solid, got {px}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1408,4 +1408,36 @@ public static class LayoutTests
         True(c.Box.ContentBox.Top > a.Box.ContentBox.Top,
             "the second row is below the first");
     }
+
+    [Test]
+    public static void AnonymousTableBoxes_TrackADynamicDisplayChange()
+    {
+        // Anonymous boxes are a function of the current display values. A pass that only ever
+        // added wrappers could not track a change to one: setting a cell to display:none wrapped
+        // it in an anonymous cell + table (a display:none box is not a proper table child), and
+        // restoring 'table-cell' left the wrappers behind, so the cell stayed nested in a table
+        // of its own instead of rejoining the row.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><body><div id='d' style='display: block'>" +
+            "<span style='display: table-cell'>a</span>" +
+            "<span id='t' style='display: table-cell'>b</span>" +
+            "<span style='display: table-cell'>c</span>" +
+            "</div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var t = FindNode(page.Root, n => n.Id == "t")!;
+        t.StyleOverrides["display"] = "none";
+        BoxEngine.Layout(page.Root, 800, 600);
+        t.StyleOverrides["display"] = "table-cell";
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var row = FindNode(page.Root, n => n.TagName == "#anon-row")!;
+        var cells = row.Children.Where(c => c.GetDisplay() == DisplayType.TableCell).ToList();
+        True(cells.Count == 3, $"all three cells rejoin the one row, got {cells.Count}");
+        True(FindNode(row, n => n.TagName == "#anon-cell") is null,
+            "no stale anonymous cell survives the round trip");
+        True(cells.All(c => Math.Abs(c.Box.ContentBox.Top - cells[0].Box.ContentBox.Top) < 0.5f),
+            "and they share the row's top");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1034,8 +1034,8 @@ public static class LayoutTests
         // beside it; the lines below start back at the container's left edge. The engine used to
         // compute one band for the whole run, so every line stayed indented.
         var flt = Block(new() { ["float"] = "left", ["width"] = "60px", ["height"] = "20px" });
-        var one = Block(new() { ["display"] = "inline-block", ["width"] = "100px", ["height"] = "30px" });
-        var two = Block(new() { ["display"] = "inline-block", ["width"] = "100px", ["height"] = "30px" });
+        var one = Block(new() { ["display"] = "inline-block", ["width"] = "60px", ["height"] = "30px" });
+        var two = Block(new() { ["display"] = "inline-block", ["width"] = "60px", ["height"] = "30px" });
         var container = Block(new() { ["width"] = "150px" }, flt, one, two);
         LayoutTree(container);
 
@@ -1129,5 +1129,22 @@ public static class LayoutTests
             $"an invalid negative width falls back to auto (fills the block), got {w.Box.ContentBox.Width}");
         True(Math.Abs(b.Box.Border.Top - 3f) < 0.5f,
             $"an invalid negative border-width falls back to medium (3px), got {b.Box.Border.Top}");
+    }
+
+    [Test]
+    public static void LineTooNarrowForItsContent_ShiftsBelowTheFloat()
+    {
+        // CSS 2.1 §9.5 rule 7: "if a shortened line box is too small to contain any content, it
+        // is shifted downward until either it fits or there are no more floats present". The
+        // engine used to leave the content overflowing the narrow band beside the float.
+        var flt = Block(new() { ["float"] = "left", ["width"] = "60px", ["height"] = "40px" });
+        var wide = Block(new() { ["display"] = "inline-block", ["width"] = "90px", ["height"] = "20px" });
+        var container = Block(new() { ["width"] = "100px" }, flt, wide);
+        LayoutTree(container);
+
+        True(Math.Abs(wide.Box.ContentBox.Left) < 0.5f,
+            $"the shifted line starts at the container's left edge, got {wide.Box.ContentBox.Left}");
+        True(wide.Box.ContentBox.Top >= 40f - 0.5f,
+            $"and below the 40px float, got {wide.Box.ContentBox.Top}");
     }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1310,4 +1310,53 @@ public static class LayoutTests
         Equal("XX", frags[0].Text);
         Equal("XX", frags[1].Text);
     }
+
+    [Test]
+    public static void AbsPos_AutoMarginsAbsorbTheLeftoverSpace()
+    {
+        // CSS 2.1 §10.3.7 / §10.6.4: with the offsets and the size all given, an auto margin takes
+        // the space left over, and two of them split it — which is how an absolutely positioned
+        // box is centred in its containing block. Auto margins used to compute to zero, so such a
+        // box sat at its 'left' offset. A non-auto margin on the other side comes off the top of
+        // the remainder first.
+        var centred = Block(new()
+        {
+            ["position"] = "absolute", ["left"] = "0", ["right"] = "0",
+            ["width"] = "100px", ["height"] = "20px",
+            ["margin-left"] = "auto", ["margin-right"] = "auto",
+        });
+        var oneSided = Block(new()
+        {
+            ["position"] = "absolute", ["left"] = "0", ["right"] = "0",
+            ["width"] = "100px", ["height"] = "20px",
+            ["margin-left"] = "auto", ["margin-right"] = "50px",
+        });
+        var outer = Block(new() { ["position"] = "relative", ["width"] = "400px", ["height"] = "100px" },
+                          centred, oneSided);
+        LayoutTree(outer);
+
+        True(Math.Abs(centred.Box.ContentBox.Left - 150f) < 0.5f,
+            $"a 100px box in a 400px block centres at x=150, got {centred.Box.ContentBox.Left}");
+        True(Math.Abs(oneSided.Box.ContentBox.Left - 250f) < 0.5f,
+            $"400 - 100 - 50 leaves 250 for the auto left margin, got {oneSided.Box.ContentBox.Left}");
+    }
+
+    [Test]
+    public static void AbsPos_RtlContainingBlockPlacesTheStaticPositionOnTheRight()
+    {
+        // §10.3.7 rule 1: with left and right both auto the box takes its static position, and
+        // under 'direction: rtl' that is measured from the right edge.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>" +
+            "#cb { position: relative; direction: rtl; width: 200px; height: 100px }" +
+            "#b { position: absolute; width: 50px; height: 20px }" +
+            "</style></head><body><div id='cb'><div id='b'></div></div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var cb = FindNode(page.Root, n => n.Id == "cb")!;
+        var b = FindNode(page.Root, n => n.Id == "b")!;
+        True(Math.Abs(b.Box.ContentBox.Right - cb.Box.ContentBox.Right) < 0.5f,
+            $"an RTL containing block puts it flush right ({cb.Box.ContentBox.Right}), got {b.Box.ContentBox.Right}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1083,4 +1083,28 @@ public static class LayoutTests
         True(px.Red == 0 && px.Green == 0 && px.Blue == 0,
             $"the top row of the background must be solid, got {px}");
     }
+
+    [Test]
+    public static void RelativeFontSize_IsComputedOnceAndInheritedAsALength()
+    {
+        // CSS 2.1 §15.7: 'font-size' computes to a length and descendants inherit THAT. The style
+        // engine handed every descendant the specified value ("2em") and re-resolved it against
+        // the parent's already-scaled size, so one `font-size: 2em` doubled again at every level:
+        // a four-deep subtree reached 512px. Only an element that declares its own font-size may
+        // rescale.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>#big { font-size: 2em } #own { font-size: 2em }" +
+            " #sh { font: 1in monospace }</style></head><body>" +
+            "<div id='big'><div id='mid'><span id='deep'>x</span></div><div id='own'>y</div></div>" +
+            "<div id='sh'>z</div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        float Fs(string id) => FindNode(page.Root, n => n.Id == id)!.GetFontSize();
+        True(Math.Abs(Fs("big") - 32f) < 0.5f, $"2em of 16px is 32, got {Fs("big")}");
+        True(Math.Abs(Fs("mid") - 32f) < 0.5f, $"an inherited font-size must not rescale, got {Fs("mid")}");
+        True(Math.Abs(Fs("deep") - 32f) < 0.5f, $"nor two levels down, got {Fs("deep")}");
+        True(Math.Abs(Fs("own") - 64f) < 0.5f, $"a re-declared 2em does scale again, got {Fs("own")}");
+        True(Math.Abs(Fs("sh") - 96f) < 0.5f, $"the 'font' shorthand sets the size (1in), got {Fs("sh")}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -910,6 +910,56 @@ public static class LayoutTests
     }
 
     [Test]
+    public static void LetterAndWordSpacing_AcceptEveryLengthUnit()
+    {
+        // §16.4/§16.5 take any length. Hand-parsing px and em only meant `72pt`, `6pc`, `2.54cm`
+        // and the rest silently computed to 0 and the text drew unspaced.
+        var node = new LayoutNode(null, "SPAN", "x", _styleCache.Style);
+        foreach (var value in new[] { "96px", "72pt", "6pc", "2.54cm", "25.4mm", "1in" })
+        {
+            node.StyleOverrides["letter-spacing"] = value;
+            node.StyleOverrides["word-spacing"] = value;
+            True(Math.Abs(node.GetLetterSpacing(16f) - 96f) < 0.05f,
+                $"letter-spacing: {value} should be 96px, got {node.GetLetterSpacing(16f)}");
+            True(Math.Abs(node.GetWordSpacing(16f) - 96f) < 0.05f,
+                $"word-spacing: {value} should be 96px, got {node.GetWordSpacing(16f)}");
+        }
+        node.StyleOverrides["letter-spacing"] = "normal";
+        True(node.GetLetterSpacing(16f) == 0f, "'normal' letter-spacing adds nothing");
+    }
+
+    [Test]
+    public static void InlineBox_ReservesItsHorizontalMarginAndPadding()
+    {
+        // CSS 2.1 §8.4: a non-replaced inline box's horizontal margins and padding take part in
+        // layout — the next thing on the line starts past them. Only its VERTICAL edges are
+        // ignored, and those only for the line box's height.
+        var lead = new LayoutNode(null, "#text", "a", _styleCache.Style);
+        lead.StyleOverrides["display"] = "inline";
+        var span = new LayoutNode(null, "SPAN", "b", _styleCache.Style);
+        span.StyleOverrides["display"] = "inline";
+        span.StyleOverrides["margin-left"] = "40px";
+        span.StyleOverrides["padding-left"] = "10px";
+        span.StyleOverrides["padding-right"] = "20px";
+        var trail = new LayoutNode(null, "#text", "c", _styleCache.Style);
+        trail.StyleOverrides["display"] = "inline";
+        var cb = Block(new() { ["width"] = "400px" }, lead, span, trail);
+        LayoutTree(cb);
+
+        var expectedSpan = lead.Box.ContentBox.Right + 40f + 10f;
+        True(Math.Abs(span.Box.ContentBox.Left - expectedSpan) < 0.5f,
+            $"span text should start past its 40px margin and 10px padding ({expectedSpan}), " +
+            $"got {span.Box.ContentBox.Left}");
+        var expectedTrail = span.Box.ContentBox.Right + 20f;
+        True(Math.Abs(trail.Box.ContentBox.Left - expectedTrail) < 0.5f,
+            $"the next text should start past the span's 20px right padding ({expectedTrail}), " +
+            $"got {trail.Box.ContentBox.Left}");
+        // The background paints over the padding box, so it covers what the line reserved.
+        True(Math.Abs(span.Box.PaddingBox.Left - (span.Box.ContentBox.Left - 10f)) < 0.01f,
+            "the padding box must include the reserved left padding");
+    }
+
+    [Test]
     public static void LineBox_IncludesTheStrutOfItsBlockContainer()
     {
         // CSS 2.1 §10.8.1: every line box starts with a zero-width inline box carrying the block

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1301,10 +1301,13 @@ public static class LayoutTests
             isSrcdoc: true, "http://test/", 800, 600);
         BoxEngine.Layout(page.Root, 800, 600);
 
-        var d = FindNode(page.Root, n => n.Id == "d")!;
         var p = FindNode(page.Root, n => n.Id == "p")!;
-        True(d.Box.ContentBox.Height > p.Box.ContentBox.Height * 1.5f,
-            $"the preformatted newline makes two line boxes, got block height {d.Box.ContentBox.Height} " +
-            $"for a line of {p.Box.ContentBox.Height}");
+        var frags = p.InlineFragments;
+        True(frags is { Count: 2 },
+            $"the preformatted newline makes two line-box fragments, got {frags?.Count ?? 0}");
+        True(frags![1].Rect.Top > frags[0].Rect.Top + 1f,
+            $"the second fragment sits below the first, got {frags[0].Rect.Top} then {frags[1].Rect.Top}");
+        Equal("XX", frags[0].Text);
+        Equal("XX", frags[1].Text);
     }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1166,4 +1166,59 @@ public static class LayoutTests
         True(Math.Abs(both.Box.ContentBox.Width - 80f) < 0.5f,
             $"min-width wins over max-width, expected 80, got {both.Box.ContentBox.Width}");
     }
+
+    [Test]
+    public static void SynthesizedBoxes_DoNotInheritTheParentsPositionOrFloat()
+    {
+        // An anonymous table box borrows its originating element's style object, so a parent's
+        // NON-inherited 'position: absolute' read back as the anonymous box's own and took it out
+        // of its parent's flow — the parent then measured no content and shrank to nothing, and
+        // the cells stacked vertically instead of sitting side by side.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><body><div style='position: relative'>" +
+            "<div id='abs' style='position: absolute; top: 0'>" +
+            "<span style='display: table-cell'>ab</span>" +
+            "<span style='display: table-cell'>cd</span>" +
+            "</div></div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var abs = FindNode(page.Root, n => n.Id == "abs")!;
+        var table = FindNode(abs, n => n.TagName == "#anon-table");
+        True(table != null, "the bare cells must be wrapped in an anonymous table");
+        True(table!.GetPosition() == PositionType.Static,
+            "an anonymous box must not pick up the parent's position");
+        True(abs.Box.ContentBox.Width > 10f,
+            $"the abs-pos box shrink-wraps to its table, got {abs.Box.ContentBox.Width}");
+        var cells = new List<LayoutNode>();
+        void Collect(LayoutNode n)
+        {
+            if (n.GetDisplay() == DisplayType.TableCell) cells.Add(n);
+            foreach (var c in n.Children) Collect(c);
+        }
+        Collect(abs);
+        True(cells.Count == 2 && Math.Abs(cells[0].Box.ContentBox.Top - cells[1].Box.ContentBox.Top) < 0.5f,
+            "the two cells share a row, so they sit at the same top");
+        True(cells[1].Box.ContentBox.Left > cells[0].Box.ContentBox.Left,
+            "and side by side");
+    }
+
+    [Test]
+    public static void PreFormattedText_KeepsItsLeadingAndTrailingSpaces()
+    {
+        // §16.6.1's "remove spaces at the start and end of a line" only applies where white-space
+        // collapses. Trimming unconditionally made a `white-space: pre` cell holding one space
+        // zero pixels wide.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><body>" +
+            "<span id='p' style='display: inline-block; white-space: pre'> </span>" +
+            "</body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var p = FindNode(page.Root, n => n.Id == "p")!;
+        Equal(" ", p.DisplayText);
+        True(p.Box.ContentBox.Width > 1f,
+            $"a preserved space must have width, got {p.Box.ContentBox.Width}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1250,4 +1250,21 @@ public static class LayoutTests
         True(Math.Abs(px.Box.ContentBox.Height - 40f) < 1f,
             $"height=\"40\" is 40, got {px.Box.ContentBox.Height}");
     }
+
+    [Test]
+    public static void ZeroLineHeight_CollapsesTheLineBox()
+    {
+        // 'line-height: 0' is a real value — it collapses the line box so the text overflows its
+        // own box. Text measurement used 0 as the sentinel for "the caller did not say", so it
+        // silently substituted the 1.4em default and the block came out several lines tall.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>#z { line-height: 0; font-size: 20px; width: 20px }" +
+            "</style></head><body><div id='z'>X X X</div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var z = FindNode(page.Root, n => n.Id == "z")!;
+        True(z.Box.ContentBox.Height < 1f,
+            $"line-height:0 collapses every line box, expected height 0, got {z.Box.ContentBox.Height}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -966,4 +966,82 @@ public static class LayoutTests
         True(px.Green > 120 && px.Red < 120,
             $"a position:fixed box must paint (expected green at 20,20), got {px}");
     }
+
+    [Test]
+    public static void FirstLetter_BecomesARealInlineBoxThatSizesTheLine()
+    {
+        // CSS 2.1 §5.12.1 + §10.8: ::first-letter is a real inline box, so its font and
+        // 'line-height' size the line box it sits on. Styling it only at paint time (re-drawing
+        // the first characters larger) left the line box sized for the parent's font, so the
+        // block was too short and the letter overlapped whatever was above it.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>" +
+            "div:first-letter { color: green; font-size: 36px; line-height: 2; }" +
+            "</style></head><body><div id='d'>)T)est</div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var d = FindNode(page.Root, n => n.Id == "d");
+        var letter = FindNode(page.Root, n => n.TagName == "#pseudo-first-letter");
+        True(letter != null, "::first-letter must generate an inline box");
+        // Leading AND trailing punctuation belong to the first letter (Ps/Pe/Pi/Pf/Po).
+        Equal(")T)", letter!.DisplayText);
+        True(Math.Abs(letter.GetFontSize() - 36f) < 0.5f,
+            $"the first-letter box must take the pseudo-element font-size, got {letter.GetFontSize()}");
+        // line-height:2 on a 36px box makes the line box 72px tall.
+        True(d!.Box.ContentBox.Height > 60f,
+            $"the first-letter box must size the line box, got {d.Box.ContentBox.Height}");
+    }
+
+    [Test]
+    public static void FirstLetter_PunctuationOnlyTextGetsNoBox()
+    {
+        // No letter to style: the run is punctuation all the way down, so no box is generated
+        // and the text is left exactly as authored.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>div:first-letter { color: green; }" +
+            "</style></head><body><div id='d'>...</div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        True(FindNode(page.Root, n => n.TagName == "#pseudo-first-letter") is null,
+            "punctuation-only text must not produce a ::first-letter box");
+    }
+
+    [Test]
+    public static void AbsPos_AutoOffsetsUseTheStaticPosition()
+    {
+        // CSS 2.1 §10.3.7 / §10.6.4: with left/top auto the box goes where it WOULD have been in
+        // normal flow, not at the containing block's origin. The abs-pos box here follows a 50px
+        // block inside an unpositioned wrapper, so it belongs at y=50 — the old code pinned it to
+        // the containing block (the relative outer div) at y=0.
+        var spacer = Block(new() { ["height"] = "50px" });
+        var abs = Block(new() { ["position"] = "absolute", ["width"] = "20px", ["height"] = "20px" });
+        var wrapper = Block(new() { ["margin-left"] = "30px" }, spacer, abs);
+        var outer = Block(new() { ["position"] = "relative", ["width"] = "200px" }, wrapper);
+        LayoutTree(outer);
+
+        True(Math.Abs(abs.Box.ContentBox.Top - 50f) < 0.5f,
+            $"static position should put the box below the 50px block, got {abs.Box.ContentBox.Top}");
+        True(Math.Abs(abs.Box.ContentBox.Left - 30f) < 0.5f,
+            $"static position should follow the wrapper's left edge (30), got {abs.Box.ContentBox.Left}");
+    }
+
+    [Test]
+    public static void LineBoxes_WidenBelowAFloatTheyAreNoLongerBesideIt()
+    {
+        // CSS 2.1 §9.5: each line box gets its own band. A float 20px tall narrows only the lines
+        // beside it; the lines below start back at the container's left edge. The engine used to
+        // compute one band for the whole run, so every line stayed indented.
+        var flt = Block(new() { ["float"] = "left", ["width"] = "60px", ["height"] = "20px" });
+        var one = Block(new() { ["display"] = "inline-block", ["width"] = "100px", ["height"] = "30px" });
+        var two = Block(new() { ["display"] = "inline-block", ["width"] = "100px", ["height"] = "30px" });
+        var container = Block(new() { ["width"] = "150px" }, flt, one, two);
+        LayoutTree(container);
+
+        True(Math.Abs(one.Box.ContentBox.Left - 60f) < 0.5f,
+            $"the first line sits beside the float (x=60), got {one.Box.ContentBox.Left}");
+        True(Math.Abs(two.Box.ContentBox.Left - 0f) < 0.5f,
+            $"the second line clears the 20px float and starts at x=0, got {two.Box.ContentBox.Left}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1147,4 +1147,23 @@ public static class LayoutTests
         True(wide.Box.ContentBox.Top >= 40f - 0.5f,
             $"and below the 40px float, got {wide.Box.ContentBox.Top}");
     }
+
+    [Test]
+    public static void MinAndMaxWidth_ClampAnInFlowBlock()
+    {
+        // CSS 2.1 §10.4. Only the absolutely-positioned path clamped, so 'min-width' and
+        // 'max-width' had no effect at all on a normal block: it just filled its container.
+        var capped = Block(new() { ["max-width"] = "40px", ["height"] = "10px" });
+        var floored = Block(new() { ["width"] = "10px", ["min-width"] = "70px", ["height"] = "10px" });
+        // min-width wins over max-width when they conflict.
+        var both = Block(new() { ["min-width"] = "80px", ["max-width"] = "20px", ["height"] = "10px" });
+        LayoutTree(Block(new() { ["width"] = "200px" }, capped, floored, both));
+
+        True(Math.Abs(capped.Box.ContentBox.Width - 40f) < 0.5f,
+            $"max-width should cap the fill width at 40, got {capped.Box.ContentBox.Width}");
+        True(Math.Abs(floored.Box.ContentBox.Width - 70f) < 0.5f,
+            $"min-width should raise the used width to 70, got {floored.Box.ContentBox.Width}");
+        True(Math.Abs(both.Box.ContentBox.Width - 80f) < 0.5f,
+            $"min-width wins over max-width, expected 80, got {both.Box.ContentBox.Width}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -881,6 +881,35 @@ public static class LayoutTests
     }
 
     [Test]
+    public static void InlineReplacedBox_ReservesItsPaddingBorderAndMargin()
+    {
+        // CSS 2.1 §8.4: the horizontal AND vertical margin/border/padding of an inline REPLACED
+        // box take part in layout (unlike a non-replaced inline box, whose vertical edges do
+        // not). The inline path passed zero edges, so `img { padding-right: 20px }` advanced the
+        // line by nothing and a following image sat flush against the first.
+        var first = Img(96, 96, new()
+        {
+            ["padding-left"] = "5px",
+            ["padding-right"] = "20px",
+            ["margin-top"] = "10px",
+        });
+        var second = Img(80, 20);
+        var cb = Block(new() { ["width"] = "400px" }, first, second);
+        LayoutTree(cb);
+
+        // The bitmap starts past the left padding, and the next image starts past the right one.
+        True(Math.Abs(first.Box.ContentBox.Left - (cb.Box.ContentBox.Left + 5f)) < 0.5f,
+            $"image content should start after its 5px left padding, got {first.Box.ContentBox.Left}");
+        var expectedSecond = cb.Box.ContentBox.Left + 5f + 96f + 20f;
+        True(Math.Abs(second.Box.ContentBox.Left - expectedSecond) < 0.5f,
+            $"next image should start at {expectedSecond} (past the 20px padding), " +
+            $"got {second.Box.ContentBox.Left}");
+        // A top margin pushes the replaced box down inside the line box it grew.
+        True(first.Box.ContentBox.Top - cb.Box.ContentBox.Top >= 9.5f,
+            $"10px top margin should offset the image, got {first.Box.ContentBox.Top - cb.Box.ContentBox.Top}");
+    }
+
+    [Test]
     public static void TextAlignRight_MovesInlineLevelBoxesNotJustText()
     {
         // CSS 2.1 §16.2 aligns the whole LINE BOX. text-align had a single consumer in the text

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1221,4 +1221,33 @@ public static class LayoutTests
         True(p.Box.ContentBox.Width > 1f,
             $"a preserved space must have width, got {p.Box.ContentBox.Width}");
     }
+
+    [Test]
+    public static void ReplacedElement_HonoursCssSizeAndPresentationalHints()
+    {
+        // §10.3.2 / §10.6.2: a CSS width/height on a replaced element overrides its intrinsic
+        // size, and HTML's width/height content attributes are presentational hints for those
+        // properties — not the intrinsic size. Reading them as intrinsic derived the missing
+        // dimension from one axis's attribute and the other axis's bitmap: width="100%" with
+        // height="50" on a 1x1 image came out 39200px tall. The inline path ignored CSS size
+        // altogether, so a percentage width left the image at its natural pixel width.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><body><div id='cb' style='width: 200px'>" +
+            "<img id='pct' width='50%' height='20' alt='x'/>" +
+            "<img id='px' width='30' height='40' alt='x'/>" +
+            "</div></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var pct = FindNode(page.Root, n => n.Id == "pct")!;
+        var px = FindNode(page.Root, n => n.Id == "px")!;
+        True(Math.Abs(pct.Box.ContentBox.Width - 100f) < 1f,
+            $"width=\"50%\" of a 200px block is 100, got {pct.Box.ContentBox.Width}");
+        True(Math.Abs(pct.Box.ContentBox.Height - 20f) < 1f,
+            $"height=\"20\" stays 20, got {pct.Box.ContentBox.Height}");
+        True(Math.Abs(px.Box.ContentBox.Width - 30f) < 1f,
+            $"width=\"30\" is 30, got {px.Box.ContentBox.Width}");
+        True(Math.Abs(px.Box.ContentBox.Height - 40f) < 1f,
+            $"height=\"40\" is 40, got {px.Box.ContentBox.Height}");
+    }
 }

--- a/Lite.Tests/LayoutTests.cs
+++ b/Lite.Tests/LayoutTests.cs
@@ -1359,4 +1359,53 @@ public static class LayoutTests
         True(Math.Abs(b.Box.ContentBox.Right - cb.Box.ContentBox.Right) < 0.5f,
             $"an RTL containing block puts it flush right ({cb.Box.ContentBox.Right}), got {b.Box.ContentBox.Right}");
     }
+
+    [Test]
+    public static void Table_CellSpacingAndCellPaddingAttributesApply()
+    {
+        // HTML 4 §11.2.1 presentational hints: cellspacing is 'border-spacing' on the table and
+        // cellpadding is 'padding' on each cell. Ignoring them left the UA defaults (2px spacing,
+        // 1px cell padding) in place, so a `cellpadding="0" cellspacing="0"` table sat 3px lower
+        // and wider than the CSS-equivalent it is meant to match.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><body>" +
+            "<table id='t' cellspacing='0' cellpadding='0'><tr><td id='c'>a</td><td>b</td></tr></table>" +
+            "</body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var t = FindNode(page.Root, n => n.Id == "t")!;
+        var c = FindNode(page.Root, n => n.Id == "c")!;
+        Equal("0px", t.StyleOverrides.GetValueOrDefault("border-spacing"));
+        True(c.Box.Padding.Top == 0f && c.Box.Padding.Left == 0f,
+            $"cellpadding=0 clears the UA cell padding, got {c.Box.Padding.Top}/{c.Box.Padding.Left}");
+        True(Math.Abs(c.Box.BorderBox.Left - t.Box.ContentBox.Left) < 0.5f,
+            $"with no spacing the first cell starts at the table's content edge, " +
+            $"got {c.Box.BorderBox.Left} vs {t.Box.ContentBox.Left}");
+    }
+
+    [Test]
+    public static void AbsolutelyPositionedTable_LaysOutAsATable()
+    {
+        // An absolutely positioned box laid its children out as plain blocks whatever its own
+        // display was, so an abs-pos <table> flowed its rows and cells as inline content — one
+        // long wrapping line of cell text instead of a grid.
+        var page = Parser.ParseChildPage(
+            "<!DOCTYPE html><html><head><style>#t { position: absolute; top: 0; left: 0 }</style></head>" +
+            "<body><table id='t' cellspacing='0' cellpadding='0'>" +
+            "<tr><td id='a'>a</td><td id='b'>b</td></tr>" +
+            "<tr><td id='c'>c</td><td>d</td></tr></table></body></html>",
+            isSrcdoc: true, "http://test/", 800, 600);
+        BoxEngine.Layout(page.Root, 800, 600);
+
+        var a = FindNode(page.Root, n => n.Id == "a")!;
+        var b = FindNode(page.Root, n => n.Id == "b")!;
+        var c = FindNode(page.Root, n => n.Id == "c")!;
+        True(Math.Abs(a.Box.ContentBox.Top - b.Box.ContentBox.Top) < 0.5f,
+            "cells of one row share a top");
+        True(b.Box.ContentBox.Left > a.Box.ContentBox.Left,
+            "and sit side by side");
+        True(c.Box.ContentBox.Top > a.Box.ContentBox.Top,
+            "the second row is below the first");
+    }
 }

--- a/Lite/Drawer.cs
+++ b/Lite/Drawer.cs
@@ -443,8 +443,10 @@ internal static class Drawer
 
             if (bgColor != SKColors.Transparent)
             {
+                // §14.2: a background paints over the PADDING box. For an inline box that is the
+                // text plus whatever horizontal padding the line reserved for it (§8.4).
                 using var bgPaint = new SKPaint { Color = bgColor };
-                canvas.DrawRect(node.Box.ContentBox, bgPaint);
+                canvas.DrawRect(node.Box.PaddingBox, bgPaint);
             }
             DrawWrappedText(canvas, node, node.DisplayText,
                 node.Box.ContentBox.Left, node.Box.ContentBox.Top,

--- a/Lite/Drawer.cs
+++ b/Lite/Drawer.cs
@@ -445,8 +445,12 @@ internal static class Drawer
         var bgColor = node.GetBackgroundColor();
         if (bgColor != SKColors.Transparent)
         {
-            using var bgPaint = new SKPaint { Color = bgColor, IsAntialias = true };
             var (rx, ry) = node.GetBorderRadius(box.PaddingBox.Width, box.PaddingBox.Height);
+            // A square background is snapped to whole device pixels (no anti-aliasing), which is
+            // what a browser does and what replaced content already does here. Anti-aliasing a
+            // box that lands on a fractional y left a half-covered fringe row, so a background
+            // and an image of the same size in the same place did not paint the same pixels.
+            using var bgPaint = new SKPaint { Color = bgColor, IsAntialias = rx > 0 || ry > 0 };
             if (rx > 0 || ry > 0) canvas.DrawRoundRect(box.PaddingBox, rx, ry, bgPaint);
             else canvas.DrawRect(box.PaddingBox, bgPaint);
         }
@@ -484,8 +488,8 @@ internal static class Drawer
             var bgColor = node.GetBackgroundColor();
             if (bgColor != SKColors.Transparent)
             {
-                using var bgPaint = new SKPaint { Color = bgColor, IsAntialias = true };
                 var (rx, ry) = node.GetBorderRadius(box.PaddingBox.Width, box.PaddingBox.Height);
+                using var bgPaint = new SKPaint { Color = bgColor, IsAntialias = rx > 0 || ry > 0 };
                 if (rx > 0 || ry > 0) canvas.DrawRoundRect(box.PaddingBox, rx, ry, bgPaint);
                 else canvas.DrawRect(box.PaddingBox, bgPaint);
             }
@@ -702,8 +706,12 @@ internal static class Drawer
         var bgColor = node.GetBackgroundColor();
         if (bgColor != SKColors.Transparent)
         {
-            using var bgPaint = new SKPaint { Color = bgColor, IsAntialias = true };
             var (rx, ry) = node.GetBorderRadius(box.PaddingBox.Width, box.PaddingBox.Height);
+            // A square background is snapped to whole device pixels (no anti-aliasing), which is
+            // what a browser does and what replaced content already does here. Anti-aliasing a
+            // box that lands on a fractional y left a half-covered fringe row, so a background
+            // and an image of the same size in the same place did not paint the same pixels.
+            using var bgPaint = new SKPaint { Color = bgColor, IsAntialias = rx > 0 || ry > 0 };
             if (rx > 0 || ry > 0) canvas.DrawRoundRect(box.PaddingBox, rx, ry, bgPaint);
             else canvas.DrawRect(box.PaddingBox, bgPaint);
         }
@@ -1395,8 +1403,12 @@ internal static class Drawer
         var bgColor = node.GetBackgroundColor();
         if (bgColor != SKColors.Transparent)
         {
-            using var bgPaint = new SKPaint { Color = bgColor, IsAntialias = true };
             var (rx, ry) = node.GetBorderRadius(box.PaddingBox.Width, box.PaddingBox.Height);
+            // A square background is snapped to whole device pixels (no anti-aliasing), which is
+            // what a browser does and what replaced content already does here. Anti-aliasing a
+            // box that lands on a fractional y left a half-covered fringe row, so a background
+            // and an image of the same size in the same place did not paint the same pixels.
+            using var bgPaint = new SKPaint { Color = bgColor, IsAntialias = rx > 0 || ry > 0 };
             if (rx > 0 || ry > 0) canvas.DrawRoundRect(box.PaddingBox, rx, ry, bgPaint);
             else canvas.DrawRect(box.PaddingBox, bgPaint);
         }
@@ -1638,30 +1650,6 @@ internal static class Drawer
                         bw.Left, node.GetBorderLeftColor(), node.GetBorderStyleLeft());
     }
 
-    /// <summary>
-    /// Length of the ::first-letter run per CSS 2.1 §5.12.1: the first letter plus any punctuation
-    /// that <em>precedes or follows</em> it — Unicode classes Ps (open), Pe (close), Pi/Pf (quotes)
-    /// and Po (other). So <c>)T)est</c> has a three-character first letter, not one.
-    /// Returns 0 when the text holds no letter at all, in which case nothing is styled.
-    /// </summary>
-    private static int FirstLetterLength(string text)
-    {
-        static bool IsFirstLetterPunctuation(char c) =>
-            System.Globalization.CharUnicodeInfo.GetUnicodeCategory(c) is
-                System.Globalization.UnicodeCategory.OpenPunctuation or
-                System.Globalization.UnicodeCategory.ClosePunctuation or
-                System.Globalization.UnicodeCategory.InitialQuotePunctuation or
-                System.Globalization.UnicodeCategory.FinalQuotePunctuation or
-                System.Globalization.UnicodeCategory.OtherPunctuation;
-
-        var i = 0;
-        while (i < text.Length && IsFirstLetterPunctuation(text[i])) i++;
-        if (i >= text.Length) return 0;   // punctuation only: no first letter to style
-        i++;                              // the letter itself
-        while (i < text.Length && IsFirstLetterPunctuation(text[i])) i++;
-        return i;
-    }
-
     private static void DrawBorderSide(SKCanvas canvas, float x1, float y1, float x2, float y2,
                                         float width, SKColor color, BorderStyle style)
     {
@@ -1733,7 +1721,9 @@ internal static class Drawer
             var rect = Math.Abs(y1 - y2) < 0.01f
                 ? new SKRect(Math.Min(x1, x2), y1 - half, Math.Max(x1, x2), y1 + half)   // horizontal
                 : new SKRect(x1 - half, Math.Min(y1, y2), x1 + half, Math.Max(y1, y2));  // vertical
-            using var fill = new SKPaint { Color = color, IsAntialias = true };
+            // Snapped to whole device pixels like the background fill above, so a border and an
+            // equally-sized background agree pixel for pixel on a fractional boundary.
+            using var fill = new SKPaint { Color = color, IsAntialias = false };
             canvas.DrawRect(rect, fill);
             return;
         }

--- a/Lite/Drawer.cs
+++ b/Lite/Drawer.cs
@@ -707,10 +707,7 @@ internal static class Drawer
         if (bgColor != SKColors.Transparent)
         {
             var (rx, ry) = node.GetBorderRadius(box.PaddingBox.Width, box.PaddingBox.Height);
-            // A square background is snapped to whole device pixels (no anti-aliasing), which is
-            // what a browser does and what replaced content already does here. Anti-aliasing a
-            // box that lands on a fractional y left a half-covered fringe row, so a background
-            // and an image of the same size in the same place did not paint the same pixels.
+            // Square backgrounds paint unantialiased — see PaintBlockDecorations.
             using var bgPaint = new SKPaint { Color = bgColor, IsAntialias = rx > 0 || ry > 0 };
             if (rx > 0 || ry > 0) canvas.DrawRoundRect(box.PaddingBox, rx, ry, bgPaint);
             else canvas.DrawRect(box.PaddingBox, bgPaint);
@@ -1404,10 +1401,7 @@ internal static class Drawer
         if (bgColor != SKColors.Transparent)
         {
             var (rx, ry) = node.GetBorderRadius(box.PaddingBox.Width, box.PaddingBox.Height);
-            // A square background is snapped to whole device pixels (no anti-aliasing), which is
-            // what a browser does and what replaced content already does here. Anti-aliasing a
-            // box that lands on a fractional y left a half-covered fringe row, so a background
-            // and an image of the same size in the same place did not paint the same pixels.
+            // Square backgrounds paint unantialiased — see PaintBlockDecorations.
             using var bgPaint = new SKPaint { Color = bgColor, IsAntialias = rx > 0 || ry > 0 };
             if (rx > 0 || ry > 0) canvas.DrawRoundRect(box.PaddingBox, rx, ry, bgPaint);
             else canvas.DrawRect(box.PaddingBox, bgPaint);

--- a/Lite/Drawer.cs
+++ b/Lite/Drawer.cs
@@ -417,13 +417,31 @@ internal static class Drawer
         if (!string.IsNullOrEmpty(node.DisplayText))
         {
             var bgColor = node.GetBackgroundColor();
+            using var font = TextMeasure.CreateFont(node);
+            using var paint = new SKPaint { Color = node.GetColor(), IsAntialias = true };
+
+            // An inline box broken over several line boxes has one fragment per line, each with
+            // the slice of text drawn there. Painting node.Box alone covered only the last line,
+            // so a preformatted <span> spanning two lines showed one background, not two.
+            if (node.InlineFragments is { Count: > 1 } fragments)
+            {
+                foreach (var (rect, text) in fragments)
+                {
+                    if (bgColor != SKColors.Transparent)
+                    {
+                        using var fragBg = new SKPaint { Color = bgColor };
+                        canvas.DrawRect(rect, fragBg);
+                    }
+                    DrawWrappedText(canvas, node, text, rect.Left, rect.Top, rect.Width, font, paint);
+                }
+                return;
+            }
+
             if (bgColor != SKColors.Transparent)
             {
                 using var bgPaint = new SKPaint { Color = bgColor };
                 canvas.DrawRect(node.Box.ContentBox, bgPaint);
             }
-            using var font = TextMeasure.CreateFont(node);
-            using var paint = new SKPaint { Color = node.GetColor(), IsAntialias = true };
             DrawWrappedText(canvas, node, node.DisplayText,
                 node.Box.ContentBox.Left, node.Box.ContentBox.Top,
                 node.Box.ContentBox.Width, font, paint);

--- a/Lite/Drawer.cs
+++ b/Lite/Drawer.cs
@@ -2297,18 +2297,8 @@ internal static class Drawer
         }
     }
 
-    /// <summary>Measures text width including letter-spacing and word-spacing.</summary>
+    /// <summary>Measures text width including letter-spacing and word-spacing. Shared with layout
+    /// (<see cref="TextMeasure.MeasureWithSpacing"/>) so the two agree on how wide the text is.</summary>
     private static float MeasureWithSpacing(string text, SKFont font, float letterSpacing, float wordSpacing)
-    {
-        if (string.IsNullOrEmpty(text)) return 0f;
-        float w = 0f;
-        foreach (var ch in text)
-        {
-            w += font.MeasureText(ch.ToString()) + letterSpacing;
-            if (ch == ' ') w += wordSpacing;
-        }
-        // Remove trailing letter-spacing
-        w -= letterSpacing;
-        return Math.Max(0f, w);
-    }
+        => TextMeasure.MeasureWithSpacing(text, font, letterSpacing, wordSpacing);
 }

--- a/Lite/Drawer.cs
+++ b/Lite/Drawer.cs
@@ -131,7 +131,10 @@ internal static class Drawer
             var node = stack.Pop();
             if (!visited.Add(node)) continue;
             if (node.GetPosition() == PositionType.Fixed)
-                PaintNode(canvas, node, viewportWidth);
+                // PaintNodeInner, not PaintNode: PaintNode skips every fixed box so the normal
+                // tree pass leaves them for this one. Routing back through it made this pass a
+                // no-op, so a position:fixed box was laid out correctly and then never painted.
+                PaintNodeInner(canvas, node, viewportWidth);
             else
                 for (int i = node.Children.Count - 1; i >= 0; i--)
                     stack.Push(node.Children[i]);
@@ -395,8 +398,15 @@ internal static class Drawer
             return;
         }
 
+        // inline-block belongs here with the other atomic inline-level boxes: it is a block
+        // CONTAINER, so it paints a background, borders and a background-image over its padding
+        // box. Leaving it out sent an inline-block with no text straight to the child recursion,
+        // which paints nothing at all — an empty sized inline-block was simply invisible — and
+        // one with text to the generic-inline branch, which fills only the content box and draws
+        // no border. (Form controls never reach here; they are dispatched by tag name above.)
         if (display == DisplayType.Block || display == DisplayType.Flex || display == DisplayType.InlineFlex
             || display == DisplayType.Table || display == DisplayType.InlineTable
+            || display == DisplayType.InlineBlock
             || display == DisplayType.TableRowGroup || display == DisplayType.TableRow || display == DisplayType.TableCell)
         {
             PaintBlock(canvas, node, viewportWidth);
@@ -2120,8 +2130,7 @@ internal static class Drawer
         var wordSpacing = node.GetWordSpacing(font.Size);
         var textIndent = node.GetTextIndent(maxWidth, font.Size);
 
-        // Resolve ::first-letter and ::first-line styles from node or parent
-        var firstLetterStyles = node.FirstLetterStyles ?? node.Parent?.FirstLetterStyles;
+        // ::first-line styles are resolved from the node or its parent block.
         var firstLineStyles = node.FirstLineStyles ?? node.Parent?.FirstLineStyles;
 
         // Apply text-transform
@@ -2145,7 +2154,6 @@ internal static class Drawer
         var lineY = y;
         var textShadow = node.GetTextShadow();
         var isFirstLine = true;
-        var firstLetterDrawn = false;
 
         var lastLineIndex = lines.Count - 1;
         var lineIndex = -1;
@@ -2238,49 +2246,10 @@ internal static class Drawer
                 DrawTextWithSpacing(canvas, line.Text, drawX + ts.OffsetX, baseline + ts.OffsetY, lineFont, sp, letterSpacing, lineWordSpacing);
             }
 
-            // Handle ::first-letter on the first character of the first line
-            if (isFirstLine && !firstLetterDrawn && firstLetterStyles != null && line.Text.Length > 0)
-            {
-                firstLetterDrawn = true;
-                var flLen = FirstLetterLength(line.Text);
-                var firstChar = line.Text[..flLen];
-                var restText = line.Text[flLen..];
-
-                // Create first-letter font/paint
-                using var flPaint = new SKPaint { Color = linePaint.Color, IsAntialias = true };
-                var flFontSize = lineFont.Size;
-                var flTypeface = lineFont.Typeface;
-
-                if (firstLetterStyles.TryGetValue("color", out var flcColor))
-                    flPaint.Color = Rendering.SvgRenderer.ParseColor(flcColor);
-                if (firstLetterStyles.TryGetValue("font-size", out var flcSize))
-                {
-                    if (flcSize.EndsWith("em") && float.TryParse(flcSize[..^2],
-                        System.Globalization.NumberStyles.Float,
-                        System.Globalization.CultureInfo.InvariantCulture, out var em))
-                        flFontSize = lineFont.Size * em;
-                    else if (flcSize.EndsWith("px") && float.TryParse(flcSize[..^2],
-                        System.Globalization.NumberStyles.Float,
-                        System.Globalization.CultureInfo.InvariantCulture, out var px))
-                        flFontSize = px;
-                }
-                if (firstLetterStyles.TryGetValue("font-weight", out var flcWeight) && flcWeight == "bold")
-                {
-                    flTypeface = SKTypeface.FromFamilyName(flTypeface.FamilyName, (int)SKFontStyleWeight.Bold,
-                        (int)flTypeface.FontStyle.Width, flTypeface.FontStyle.Slant) ?? flTypeface;
-                }
-
-                using var flFont = new SKFont(flTypeface, flFontSize);
-                var flWidth = flFont.MeasureText(firstChar, out _);
-
-                DrawTextWithSpacing(canvas, firstChar, drawX, baseline, flFont, flPaint, 0, 0);
-                if (restText.Length > 0)
-                    DrawTextWithSpacing(canvas, restText, drawX + flWidth, baseline, lineFont, linePaint, letterSpacing, lineWordSpacing);
-            }
-            else
-            {
-                DrawTextWithSpacing(canvas, line.Text, drawX, baseline, lineFont, linePaint, letterSpacing, lineWordSpacing);
-            }
+            // ::first-letter is not handled here: the Parser splits it into a real inline box
+            // (#pseudo-first-letter) so it takes part in layout, and it paints as ordinary inline
+            // content through this same routine.
+            DrawTextWithSpacing(canvas, line.Text, drawX, baseline, lineFont, linePaint, letterSpacing, lineWordSpacing);
 
             if (underline)
             {

--- a/Lite/Drawer.cs
+++ b/Lite/Drawer.cs
@@ -448,6 +448,11 @@ internal static class Drawer
                 using var bgPaint = new SKPaint { Color = bgColor };
                 canvas.DrawRect(node.Box.PaddingBox, bgPaint);
             }
+            // NOTE: an inline box's BORDERS are still not drawn. Reserving room for them in the
+            // line and stroking them here was measured against the CSS 2.1 suite and came out
+            // flat: it fixes the tests that expect a visible inline border, and breaks the same
+            // number of block-in-inline ones, where an inline box broken around a block needs one
+            // fragment box per piece before its edges can land in the right places.
             DrawWrappedText(canvas, node, node.DisplayText,
                 node.Box.ContentBox.Left, node.Box.ContentBox.Top,
                 node.Box.ContentBox.Width, font, paint);

--- a/Lite/Drawer.cs
+++ b/Lite/Drawer.cs
@@ -332,6 +332,10 @@ internal static class Drawer
                 return;
 
             case "IMG":
+                // An image is a replaced box like any other: its own background, border and
+                // outline paint under/around the bitmap. The inline path reserves room for those
+                // edges, so skipping them here would leave a gap with nothing drawn in it.
+                PaintBlockDecorations(canvas, node);
                 PaintImage(canvas, node);
                 return;
 

--- a/Lite/Drawer.cs
+++ b/Lite/Drawer.cs
@@ -2107,6 +2107,11 @@ internal static class Drawer
         canvas.DrawRect(outlineRect, paint);
     }
 
+    /// <summary>The width of line <paramref name="index"/>'s float band, or <paramref name="fallback"/>
+    /// when the run has none.</summary>
+    private static float LineBandWidth(List<(float X, float Width)>? bands, int index, float fallback)
+        => bands is { Count: > 0 } ? bands[Math.Min(index, bands.Count - 1)].Width : fallback;
+
     private static void DrawWrappedText(SKCanvas canvas, LayoutNode node, string text,
                                         float x, float y, float maxWidth,
                                         SKFont font, SKPaint paint)
@@ -2126,7 +2131,12 @@ internal static class Drawer
         // Apply text-transform
         text = StyleExtensions.ApplyTextTransform(text, textTransform);
 
-        var lines = TextMeasure.WrapText(text, maxWidth, font, whiteSpace, node.GetLineHeight(node.GetFontSize()));
+        // Layout may have wrapped this text against a per-line band (text beside a float, CSS 2.1
+        // §9.5). Painting has to use exactly the same bands or the lines break in different places
+        // than they were measured.
+        var bands = node.LineBands;
+        var lines = TextMeasure.WrapText(text, maxWidth, font, whiteSpace, node.GetLineHeight(node.GetFontSize()),
+                                          bands?.Select(b => b.Width).ToList());
 
         // text-overflow: ellipsis — when overflow is clipped and only one line, truncate with "…"
         // Check node itself OR its parent block (text-overflow is non-inherited; inline children
@@ -2159,26 +2169,34 @@ internal static class Drawer
             // the available width (CSS 2.1 §16.2). Last lines and single-word lines stay unmodified.
             var lineWordSpacing = wordSpacing;
             var justified = false;
-            if (textAlign == TextAlign.Justify && lineIndex != lastLineIndex && lineWidth < maxWidth)
+            if (textAlign == TextAlign.Justify && lineIndex != lastLineIndex && lineWidth < LineBandWidth(bands, lineIndex, maxWidth))
             {
                 var gaps = line.Text.Count(c => c == ' ');
                 if (gaps > 0)
                 {
-                    lineWordSpacing = wordSpacing + (maxWidth - lineWidth) / gaps;
+                    lineWordSpacing = wordSpacing + (LineBandWidth(bands, lineIndex, maxWidth) - lineWidth) / gaps;
                     justified = true;
                 }
             }
 
-            // Compute x offset for text-align
+            // Compute x offset for text-align, within this line's own band when floats gave it one.
+            var lineX0 = x;
+            var lineMaxW = maxWidth;
+            if (bands is { Count: > 0 })
+            {
+                var band = bands[Math.Min(lineIndex, bands.Count - 1)];
+                lineX0 = band.X;
+                lineMaxW = band.Width;
+            }
             var drawX = textAlign switch
             {
-                TextAlign.Center => x + (maxWidth - lineWidth) / 2f,
-                TextAlign.Right => x + maxWidth - lineWidth,
-                _ => x,
+                TextAlign.Center => lineX0 + (lineMaxW - lineWidth) / 2f,
+                TextAlign.Right => lineX0 + lineMaxW - lineWidth,
+                _ => lineX0,
             };
 
             // A justified line visually spans the full width (used for underline/strike extents).
-            var drawnWidth = justified ? maxWidth : lineWidth;
+            var drawnWidth = justified ? LineBandWidth(bands, lineIndex, maxWidth) : lineWidth;
 
             // Apply text-indent on first line
             if (isFirstLine && textIndent != 0f)

--- a/Lite/Extensions/DrawCommandExtensions.cs
+++ b/Lite/Extensions/DrawCommandExtensions.cs
@@ -1177,6 +1177,17 @@ public static class StyleExtensions
     public static float GetWidth(this LayoutNode node, float total = 0, float size = 0)
         => GetSizeOrDefault(node, PropertyNames.Width, total, size > 0 ? size : node.GetFontSize(), 0f);
 
+    /// <summary>True when width is auto/unset — the companion of <see cref="IsAutoHeight"/>.
+    /// Layout must not use "GetWidth() &gt; 0" to mean "a width was specified": 'width: 0' is a
+    /// perfectly good used width, and treating it as auto made such a box fill its container.</summary>
+    public static bool IsAutoWidth(this LayoutNode node)
+    {
+        if (node.TryResolveStyle(PropertyNames.Width, out var w))
+            return string.IsNullOrEmpty(w) || w.Trim() is "auto";
+        var raw = node.Style.GetProperty(PropertyNames.Width).RawValue;
+        return raw is null or Constant<Length>;
+    }
+
     // Margins
     public static float GetMarginTop(this LayoutNode node, float total = 0, float size = 0) => GetSize(node, PropertyNames.MarginTop, total, size);
     public static float GetMarginRight(this LayoutNode node, float total = 0, float size = 0) => GetSize(node, PropertyNames.MarginRight, total, size);

--- a/Lite/Extensions/DrawCommandExtensions.cs
+++ b/Lite/Extensions/DrawCommandExtensions.cs
@@ -55,11 +55,43 @@ public static class StyleExtensions
         catch { return ""; }
     }
 
+    /// <summary>
+    /// CSS 2.1 §9.7: a floated or absolutely-positioned box is always block-level, so its
+    /// specified 'display' is "blockified" — 'inline-table' becomes 'table', and 'inline',
+    /// 'inline-block', 'table-caption' and every internal table display becomes 'block'.
+    /// Everything else (including 'block', 'table' and 'list-item') is left as specified.
+    /// <para>Only real elements are considered. Synthesized nodes (<c>#text</c>, the anonymous
+    /// table boxes, generated content) share their originating element's
+    /// <see cref="LayoutNode.Style"/> object, so a floated parent's non-inherited 'float' would
+    /// otherwise read back as their own — the same trap that once spawned phantom floats from
+    /// whitespace text nodes.</para>
+    /// </summary>
+    private static string BlockifyForFloatOrPosition(LayoutNode node, string raw)
+    {
+        if (node.TagName.Length > 0 && node.TagName[0] == '#') return raw;
+        if (raw is "none" or "block" or "table" or "list-item" or "flex" or "") return raw;
+
+        var pos = node.GetPosition();
+        if (node.GetFloat() == FloatType.None &&
+            pos != PositionType.Absolute && pos != PositionType.Fixed) return raw;
+
+        return raw switch
+        {
+            "inline-table" => "table",
+            "inline-flex" => "flex",
+            "inline" or "inline-block" or "table-caption" or "table-row-group" or "table-row" or
+            "table-cell" or "table-column" or "table-column-group" or "table-header-group" or
+            "table-footer-group" => "block",
+            _ => raw,
+        };
+    }
+
     public static DisplayType GetDisplay(this LayoutNode node)
     {
         var raw = node.TryResolveStyle(PropertyNames.Display, out var ov)
             ? ov
             : node.Style.GetPropertyValueSafe(PropertyNames.Display);
+        raw = BlockifyForFloatOrPosition(node, raw);
         return raw switch
         {
             "block" or "flow-root" => DisplayType.Block,
@@ -444,7 +476,7 @@ public static class StyleExtensions
         var close = raw.IndexOf(')');
         if (!raw.StartsWith("rect", StringComparison.OrdinalIgnoreCase) || open < 0 || close < 0) return null;
 
-        var parts = raw[(open + 1)..close].Split([',', ' '], StringSplitOptions.RemoveEmptyEntries);
+        var parts = raw[(open + 1)..close].Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length < 4) return null;
 
         var box = node.Box.BorderBox;

--- a/Lite/Extensions/DrawCommandExtensions.cs
+++ b/Lite/Extensions/DrawCommandExtensions.cs
@@ -229,6 +229,21 @@ public static class StyleExtensions
     public static float GetMaxHeight(this LayoutNode node, float total = 0, float size = 0)
         => GetSizeOrDefault(node, PropertyNames.MaxHeight, total, size, float.PositiveInfinity);
 
+    /// <summary>CSS 2.1 §9.2.1.1: an inline box containing a BLOCK-level box is broken around it,
+    /// and its margins/borders/padding belong to the first and last fragment only. Neither the
+    /// line (which sees one fragment at a time) nor the painter (which has no fragment boxes for
+    /// a non-leaf inline box) can place those edges correctly, so both leave them off entirely
+    /// rather than repeat them on every piece.</summary>
+    public static bool IsBrokenAroundBlock(this LayoutNode node)
+    {
+        if (node.GetDisplay() is not (DisplayType.Inline or DisplayType.None)) return false;
+        foreach (var child in node.Children)
+            if (child.GetDisplay() is DisplayType.Block or DisplayType.Flex or DisplayType.Table
+                                    or DisplayType.ListItem)
+                return true;
+        return false;
+    }
+
     public static bool IsAutoMarginTop(this LayoutNode node) => IsAutoMargin(node, PropertyNames.MarginTop);
     public static bool IsAutoMarginBottom(this LayoutNode node) => IsAutoMargin(node, PropertyNames.MarginBottom);
 

--- a/Lite/Extensions/DrawCommandExtensions.cs
+++ b/Lite/Extensions/DrawCommandExtensions.cs
@@ -1153,10 +1153,23 @@ public static class StyleExtensions
     // font-size to a px length already, so that common case returns immediately without recursing.
     public static float GetFontSize(this LayoutNode node)
     {
-        if (!node.TryResolveStyle(PropertyNames.FontSize, out _) &&
-            node.Style.GetProperty(PropertyNames.FontSize).RawValue is Length l && l.Type == Length.Unit.Px)
+        // A value set on the node itself (an author/pseudo-element declaration the Parser stored,
+        // or element.style.fontSize from script) wins and resolves against the parent's size.
+        if (node.TryResolveStyle(PropertyNames.FontSize, out var own) && !string.IsNullOrEmpty(own))
+        {
+            var basis = node.Parent?.GetFontSize() ?? Parser.DefaultFontSizePx;
+            return GetSize(node, PropertyNames.FontSize, total: basis, size: basis, defaultValue: basis);
+        }
+        // Otherwise the Parser's computed length, which descendants inherit as-is.
+        if (node.ComputedFontSize is { } computed) return computed;
+        // Synthesized boxes (#text, anonymous table boxes, generated content) share their parent's
+        // style object, so re-resolving a relative 'font-size' there would scale it a second time.
+        if (node.TagName.Length > 0 && node.TagName[0] == '#' && node.Parent is { } synthParent)
+            return synthParent.GetFontSize();
+
+        if (node.Style.GetProperty(PropertyNames.FontSize).RawValue is Length l && l.Type == Length.Unit.Px)
             return (float)l.Value;
-        var parentFs = node.Parent?.GetFontSize() ?? 16f;
+        var parentFs = node.Parent?.GetFontSize() ?? Parser.DefaultFontSizePx;
         return GetSize(node, PropertyNames.FontSize, total: parentFs, size: parentFs, defaultValue: parentFs);
     }
     // em/rem in width/height resolve against the element's own font-size; auto/unset → 0 so the

--- a/Lite/Extensions/DrawCommandExtensions.cs
+++ b/Lite/Extensions/DrawCommandExtensions.cs
@@ -627,25 +627,23 @@ public static class StyleExtensions
     }
 
     public static float GetLetterSpacing(this LayoutNode node, float fontSize = 16)
-    {
-        var raw = node.TryResolveStyle("letter-spacing", out var ov)
-            ? ov : node.Style.GetPropertyValueSafe("letter-spacing");
-        if (string.IsNullOrWhiteSpace(raw) || raw == "normal") return 0f;
-        raw = raw.Trim();
-        if (raw.EndsWith("px") && float.TryParse(raw[..^2], NumberStyles.Float, CultureInfo.InvariantCulture, out var px)) return px;
-        if (raw.EndsWith("em") && float.TryParse(raw[..^2], NumberStyles.Float, CultureInfo.InvariantCulture, out var em)) return em * fontSize;
-        return 0f;
-    }
+        => GetSpacing(node, "letter-spacing", fontSize);
 
     public static float GetWordSpacing(this LayoutNode node, float fontSize = 16)
+        => GetSpacing(node, "word-spacing", fontSize);
+
+    /// <summary>'letter-spacing'/'word-spacing' take ANY length unit. Hand-parsing px and em only
+    /// silently dropped `72pt`, `2pc`, `2.54cm` and the rest to 0 — every non-px spacing test drew
+    /// its text unspaced.</summary>
+    private static float GetSpacing(LayoutNode node, string property, float fontSize)
     {
-        var raw = node.TryResolveStyle("word-spacing", out var ov)
-            ? ov : node.Style.GetPropertyValueSafe("word-spacing");
-        if (string.IsNullOrWhiteSpace(raw) || raw == "normal") return 0f;
+        var raw = node.TryResolveStyle(property, out var ov)
+            ? ov : node.Style.GetPropertyValueSafe(property);
+        if (string.IsNullOrWhiteSpace(raw)) return 0f;
         raw = raw.Trim();
-        if (raw.EndsWith("px") && float.TryParse(raw[..^2], NumberStyles.Float, CultureInfo.InvariantCulture, out var px)) return px;
-        if (raw.EndsWith("em") && float.TryParse(raw[..^2], NumberStyles.Float, CultureInfo.InvariantCulture, out var em)) return em * fontSize;
-        return 0f;
+        if (raw.Equals("normal", StringComparison.OrdinalIgnoreCase)) return 0f;
+        if (TryEvalCalc(raw, 0f, fontSize, 0f, out var calcPx)) return calcPx;
+        return CssUnits.TryParse(raw, fontSize, 0f, 0f, 0f, out var px) ? px : 0f;
     }
 
     public static float GetTextIndent(this LayoutNode node, float totalWidth = 0, float fontSize = 16)
@@ -1517,9 +1515,17 @@ public static class StyleExtensions
             return Rendering.SvgRenderer.ParseHsl(lower);
         }
 
-        // Hex and named colours — SkiaSharp handles all CSS named colours and hex formats
+        // Hex formats.
         if (SKColor.TryParse(value, out var skColor))
             return skColor;
+
+        // CSS named colours. SKColor.TryParse only understands hex, so a keyword arriving here —
+        // which is how every colour written into StyleOverrides looks, e.g. the 'red' pulled out
+        // of a `background: red url(...)` shorthand — silently fell through to whatever AngleSharp
+        // had computed for the element, quietly losing to a lower-specificity rule.
+        var named = AngleSharp.Css.Values.Color.FromName(lower);
+        if (named.HasValue)
+            return new SKColor(named.Value.R, named.Value.G, named.Value.B, named.Value.A);
 
         return null;
     }

--- a/Lite/Extensions/DrawCommandExtensions.cs
+++ b/Lite/Extensions/DrawCommandExtensions.cs
@@ -1182,6 +1182,7 @@ public static class StyleExtensions
     /// callers must NOT treat as an explicit height — auto height is content-based.</summary>
     public static bool IsAutoHeight(this LayoutNode node)
     {
+        if (IsNegativeSize(node, PropertyNames.Height)) return true;   // invalid → as if unset
         if (node.TryResolveStyle(PropertyNames.Height, out var h))
             return string.IsNullOrEmpty(h) || h.Trim() is "auto";
         var raw = node.Style.GetProperty(PropertyNames.Height).RawValue;
@@ -1195,6 +1196,7 @@ public static class StyleExtensions
     /// perfectly good used width, and treating it as auto made such a box fill its container.</summary>
     public static bool IsAutoWidth(this LayoutNode node)
     {
+        if (IsNegativeSize(node, PropertyNames.Width)) return true;    // invalid → as if unset
         if (node.TryResolveStyle(PropertyNames.Width, out var w))
             return string.IsNullOrEmpty(w) || w.Trim() is "auto";
         var raw = node.Style.GetProperty(PropertyNames.Width).RawValue;
@@ -1496,6 +1498,20 @@ public static class StyleExtensions
             };
         if (computed > 0f) return computed;
 
+        var side = propertyName.Replace("border-", "").Replace("-width", "");
+
+        // A NEGATIVE width is invalid: the declaration is dropped, so the initial 'medium' applies
+        // wherever that side has a visible style (`border-top-width: -1px` next to
+        // `border-top-style: solid` still paints a 3px line). Checked before the shorthand probe
+        // below, whose serialized text would report the invalid length as an authored width.
+        if (computed < 0f)
+        {
+            var styleProp = $"border-{side}-style";
+            var declaredStyle = (node.TryResolveStyle(styleProp, out var sv)
+                ? sv : node.Style.GetPropertyValueSafe(styleProp))?.Trim().ToLowerInvariant();
+            return !string.IsNullOrEmpty(declaredStyle) && declaredStyle is not ("none" or "hidden") ? 3f : 0f;
+        }
+
         // A computed 0 is usually genuine, but AngleSharp gets ONE case wrong: in the `border`
         // shorthand with the width omitted (`border: solid black`) it sets border-*-style correctly
         // yet computes border-*-width to 0px instead of the initial 'medium'. That form is very
@@ -1503,7 +1519,6 @@ public static class StyleExtensions
         // Detect it from the shorthand's own text: if it declares a visible style but contains no
         // width token, the used width is 'medium'. An authored zero (`border: 0 solid black`,
         // `border-width: 0`) still has a width token, or no shorthand, so it stays 0.
-        var side = propertyName.Replace("border-", "").Replace("-width", "");
         foreach (var shorthand in new[] { $"border-{side}", "border" })
         {
             var decl = node.TryResolveStyle(shorthand, out var dv)
@@ -1523,13 +1538,18 @@ public static class StyleExtensions
             if (hasWidthToken) return 0f;                       // the zero was authored
             if (style is not null and not "none" and not "hidden") return 3f;   // initial 'medium'
         }
+
         return 0f;
     }
 
     private static readonly HashSet<string> BorderStyleKeywords = new(StringComparer.Ordinal)
     { "none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset" };
 
-    /// <summary>Returns a size property value or <paramref name="defaultValue"/> when unset/auto/none.</summary>
+    /// <summary>Returns a size property value or <paramref name="defaultValue"/> when unset/auto/none.
+    /// A negative value is invalid for every box dimension ('width', 'height', the min/max pair),
+    /// so the declaration is dropped and the property falls back to its initial value — AngleSharp
+    /// keeps such a declaration, and using it produced a zero-sized box where the spec asks for
+    /// the auto/none behaviour.</summary>
     private static float GetSizeOrDefault(LayoutNode node, string propertyName, float total, float size, float defaultValue, float viewportSize = -1f)
     {
         var vp = viewportSize >= 0 ? viewportSize : total;
@@ -1538,15 +1558,26 @@ public static class StyleExtensions
         {
             overrideStr = overrideStr.Trim();
             if (overrideStr is "" or "auto" or "none") return defaultValue;
-            if (TryEvalCalc(overrideStr, total, size, vp, out var calcPx)) return calcPx;
-            if (CssUnits.TryParse(overrideStr, size, total, vp, vp, out var lp)) return lp;
+            if (TryEvalCalc(overrideStr, total, size, vp, out var calcPx)) return calcPx < 0f ? defaultValue : calcPx;
+            if (CssUnits.TryParse(overrideStr, size, total, vp, vp, out var lp)) return lp < 0f ? defaultValue : lp;
         }
 
         var raw = node.Style.GetProperty(propertyName).RawValue;
         if (raw is null or Constant<Length>) return defaultValue; // auto/none/unset
         if (raw is not Length length) return defaultValue;
 
-        return CssUnits.ToPx(length, size, total, vp, vp);
+        var px = CssUnits.ToPx(length, size, total, vp, vp);
+        return px < 0f ? defaultValue : px;
+    }
+
+    /// <summary>True when a size property's declared value is a negative length — invalid, so the
+    /// property behaves as if it had not been declared at all.</summary>
+    private static bool IsNegativeSize(LayoutNode node, string propertyName)
+    {
+        if (node.TryResolveStyle(propertyName, out var ov) && !string.IsNullOrWhiteSpace(ov))
+            return CssUnits.TryParse(ov.Trim(), node.GetFontSize(), 0, 0, 0, out var opx) && opx < 0f;
+        return node.Style.GetProperty(propertyName).RawValue is Length l &&
+               CssUnits.ToPx(l, node.GetFontSize(), 0, 0, 0) < 0f;
     }
 
     /// <summary>

--- a/Lite/Extensions/DrawCommandExtensions.cs
+++ b/Lite/Extensions/DrawCommandExtensions.cs
@@ -941,19 +941,44 @@ public static class StyleExtensions
     {
         var raw = node.TryResolveStyle("background-repeat", out var ov)
             ? ov : node.Style.GetPropertyValueSafe("background-repeat");
-        if (string.IsNullOrWhiteSpace(raw)) return "repeat";
-        return raw.Trim();
+        raw = raw?.Trim();
+        // AngleSharp reports an unset longhand of a shorthand as the literal "initial"; passing
+        // that on made `background: green` behave as though it had no repeat at all.
+        if (string.IsNullOrWhiteSpace(raw) || raw is "initial" or "unset") return "repeat";
+        return raw;
     }
 
+    /// <summary>
+    /// The two components of 'background-position' (CSS 2.1 §14.2.1). Handles the forms the value
+    /// actually arrives in: AngleSharp serialises the pair as a tuple ("(initial, 50%)"), reports
+    /// an unset longhand of a shorthand as "initial", and a single value leaves the other axis
+    /// centred — the old space-split produced "(initial," as the X component of all three.
+    /// </summary>
     public static (string X, string Y) GetBackgroundPosition(this LayoutNode node)
     {
         var raw = node.TryResolveStyle("background-position", out var ov)
             ? ov : node.Style.GetPropertyValueSafe("background-position");
-        if (string.IsNullOrWhiteSpace(raw)) return ("0%", "0%");
-        var parts = raw.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        var x = parts.Length > 0 ? parts[0] : "0%";
-        var y = parts.Length > 1 ? parts[1] : "50%";
-        return (x, y);
+        raw = raw?.Trim();
+        if (string.IsNullOrWhiteSpace(raw) || raw is "initial" or "unset") return ("0%", "0%");
+
+        // "(x, y)" → "x y"
+        if (raw.StartsWith('(') && raw.EndsWith(')'))
+            raw = raw[1..^1].Replace(',', ' ');
+
+        var parts = raw.Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+        static string Norm(string v) => v is "initial" or "unset" ? "0%" : v;
+        static bool IsVertical(string v) => v is "top" or "bottom";
+        static bool IsHorizontal(string v) => v is "left" or "right";
+
+        if (parts.Length == 0) return ("0%", "0%");
+        if (parts.Length == 1)
+            // One value sets its own axis; the other is centred.
+            return IsVertical(parts[0]) ? ("50%", parts[0]) : (Norm(parts[0]), "50%");
+
+        // The keywords may be written vertical-first ("bottom left").
+        return IsVertical(parts[0]) && IsHorizontal(parts[1])
+            ? (parts[1], parts[0])
+            : (Norm(parts[0]), Norm(parts[1]));
     }
 
     /// <summary>True when <c>background-attachment: fixed</c> — the background is positioned

--- a/Lite/Extensions/DrawCommandExtensions.cs
+++ b/Lite/Extensions/DrawCommandExtensions.cs
@@ -229,10 +229,18 @@ public static class StyleExtensions
     public static float GetMaxHeight(this LayoutNode node, float total = 0, float size = 0)
         => GetSizeOrDefault(node, PropertyNames.MaxHeight, total, size, float.PositiveInfinity);
 
-    public static bool IsAutoMarginTop(this LayoutNode node) =>
-        node.Style.GetProperty(PropertyNames.MarginTop).RawValue is Constant<Length>;
-    public static bool IsAutoMarginBottom(this LayoutNode node) =>
-        node.Style.GetProperty(PropertyNames.MarginBottom).RawValue is Constant<Length>;
+    public static bool IsAutoMarginTop(this LayoutNode node) => IsAutoMargin(node, PropertyNames.MarginTop);
+    public static bool IsAutoMarginBottom(this LayoutNode node) => IsAutoMargin(node, PropertyNames.MarginBottom);
+
+    /// <summary>True when a margin is 'auto'. Reads the node's own resolved value first, so a
+    /// margin set by script or by the engine's own cascade counts — checking only the AngleSharp
+    /// style made those invisible, and an auto margin that is not seen simply computes to 0.</summary>
+    private static bool IsAutoMargin(LayoutNode node, string property)
+    {
+        if (node.TryResolveStyle(property, out var ov))
+            return ov.Trim().Equals("auto", StringComparison.OrdinalIgnoreCase);
+        return node.Style.GetProperty(property).RawValue is Constant<Length>;
+    }
 
     /// <summary>Returns true when min-width is auto/unset (not explicitly set to a length).</summary>
     public static bool IsAutoMinWidth(this LayoutNode node)
@@ -1165,11 +1173,9 @@ public static class StyleExtensions
     }
 
     /// <summary>Returns true when the given horizontal margin side is 'auto'.</summary>
-    public static bool IsAutoMarginLeft(this LayoutNode node) =>
-        node.Style.GetProperty(PropertyNames.MarginLeft).RawValue is Constant<Length>;
+    public static bool IsAutoMarginLeft(this LayoutNode node) => IsAutoMargin(node, PropertyNames.MarginLeft);
 
-    public static bool IsAutoMarginRight(this LayoutNode node) =>
-        node.Style.GetProperty(PropertyNames.MarginRight).RawValue is Constant<Length>;
+    public static bool IsAutoMarginRight(this LayoutNode node) => IsAutoMargin(node, PropertyNames.MarginRight);
 
     public static SKColor GetBackgroundColor(this LayoutNode node) => GetColor(node, PropertyNames.BackgroundColor, SKColors.Transparent);
     public static SKColor GetColor(this LayoutNode node) => GetColor(node, PropertyNames.Color, SKColors.Black);

--- a/Lite/Extensions/DrawCommandExtensions.cs
+++ b/Lite/Extensions/DrawCommandExtensions.cs
@@ -426,6 +426,21 @@ public static class StyleExtensions
         return fontSize * 1.4f;
     }
 
+    /// <summary>True when 'line-height' computes to 'normal' — i.e. nothing declared a length or a
+    /// number, so <see cref="GetLineHeight"/> fell through to its font-size multiple.</summary>
+    public static bool IsNormalLineHeight(this LayoutNode node)
+    {
+        if (node.TryResolveStyle(PropertyNames.LineHeight, out var ov))
+        {
+            ov = ov.Trim();
+            if (ov.Length > 0 && !ov.Equals("normal", StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+        var str = node.Style.GetPropertyValueSafe(PropertyNames.LineHeight);
+        if (!string.IsNullOrEmpty(str) && str != "normal") return false;
+        return node.Style.GetProperty(PropertyNames.LineHeight).RawValue is not Length;
+    }
+
     public static WhiteSpace GetWhiteSpace(this LayoutNode node)
     {
         var raw = node.TryResolveStyle(PropertyNames.WhiteSpace, out var ov)

--- a/Lite/Interaction/FormSubmitter.cs
+++ b/Lite/Interaction/FormSubmitter.cs
@@ -175,10 +175,7 @@ internal static class FormSubmitter
     private static string Resolve(string action, string? baseUrl)
     {
         if (string.IsNullOrEmpty(action)) return baseUrl ?? "";
-        if (Uri.TryCreate(action, UriKind.Absolute, out _)) return action;
-        if (baseUrl is not null && Uri.TryCreate(new Uri(baseUrl), action, out var resolved))
-            return resolved.ToString();
-        return action;
+        return Lite.Network.UrlUtils.Resolve(action, baseUrl) ?? action;
     }
 
     private static IEnumerable<LayoutNode> Descendants(LayoutNode root)

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -1695,6 +1695,10 @@ internal static class BoxEngine
         }
         if (placed.Count > lineStart) CommitLine();
 
+        // A node can end up with several fragments (a forced break inside it, or a run that wrapped);
+        // start each layout pass from a clean list so a re-layout does not accumulate stale ones.
+        foreach (var (item, _, _) in placed) item.Node.InlineFragments = null;
+
         foreach (var (item, relX, relY) in placed)
         {
             ApplyInlineItem(item, originX + relX, originY + relY, viewportWidth, viewportHeight);
@@ -2054,10 +2058,16 @@ internal static class BoxEngine
             case InlineItemKind.Text:
             case InlineItemKind.LineBreak:
                 {
-                    node.Box = new BoxDimensions
+                    var rect = new SKRect(absX, absY, absX + item.ContentW, absY + item.ContentH);
+                    // Record every fragment, and let Box span them all: an inline box broken over
+                    // two lines has one rect per line, and painting only the last one lost the
+                    // background and borders of every line above it.
+                    if (item.Kind == InlineItemKind.Text)
                     {
-                        ContentBox = new SKRect(absX, absY, absX + item.ContentW, absY + item.ContentH),
-                    };
+                        (node.InlineFragments ??= []).Add((rect, item.Text ?? ""));
+                        if (node.InlineFragments.Count > 1) rect = SKRect.Union(node.Box.ContentBox, rect);
+                    }
+                    node.Box = new BoxDimensions { ContentBox = rect };
                     break;
                 }
         }

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -715,20 +715,6 @@ internal static class BoxEngine
         var usedW = replaced?.Width ?? explicitW;
         var boxWidth = hasUsedW ? usedW : availableWidth - margin.Left - margin.Right;
 
-        // margin: auto centering — when the used width is known and one or both horizontal margins are auto
-        if (hasUsedW)
-        {
-            var leftAuto = node.IsAutoMarginLeft();
-            var rightAuto = node.IsAutoMarginRight();
-            if (leftAuto || rightAuto)
-            {
-                var remaining = availableWidth - usedW - border.Left - border.Right - padding.Left - padding.Right;
-                if (leftAuto && rightAuto) { margin.Left = margin.Right = MathF.Max(0, remaining / 2f); }
-                else if (leftAuto) { margin.Left = MathF.Max(0, remaining); }
-                else { margin.Right = MathF.Max(0, remaining); }
-            }
-        }
-
         // box-sizing: with content-box (the default), an explicit `width` IS the content width —
         // padding/border are added outside it. Only border-box (and the auto/fill case) subtracts
         // padding+border from the box width. (Height already honors this below.)
@@ -736,6 +722,44 @@ internal static class BoxEngine
         var contentW = (hasUsedW && !isBorderBoxW)
             ? Math.Max(0f, usedW)
             : Math.Max(0f, boxWidth - border.Left - border.Right - padding.Left - padding.Right);
+
+        // CSS 2.1 §10.4: clamp the tentative used width to max-width, then min-width (min wins),
+        // and re-run the width rules with the clamped value. Only the absolutely-positioned path
+        // did this, so 'min-width' and 'max-width' had no effect at all on an in-flow block.
+        // A percentage that cannot be resolved (no containing-block width) computes to 'none'/0.
+        var clampedW = contentW;
+        var maxW = node.GetMaxWidth(availableWidth, fontSize);
+        if (maxW < float.PositiveInfinity && !(IsPercentValue(node, "max-width") && availableWidth <= 0f))
+        {
+            var maxContent = isBorderBoxW
+                ? Math.Max(0f, maxW - border.Left - border.Right - padding.Left - padding.Right) : maxW;
+            if (clampedW > maxContent) clampedW = maxContent;
+        }
+        var minW = node.GetMinWidth(availableWidth, fontSize);
+        if (minW > 0f && !(IsPercentValue(node, "min-width") && availableWidth <= 0f))
+        {
+            var minContent = isBorderBoxW
+                ? Math.Max(0f, minW - border.Left - border.Right - padding.Left - padding.Right) : minW;
+            if (clampedW < minContent) clampedW = minContent;
+        }
+        // A clamped box has a known width, so auto margins centre it like an explicit one does.
+        var widthIsKnown = hasUsedW || clampedW != contentW;
+        contentW = clampedW;
+
+        // margin: auto centering — when the used width is known and one or both horizontal margins are auto
+        if (widthIsKnown)
+        {
+            var leftAuto = node.IsAutoMarginLeft();
+            var rightAuto = node.IsAutoMarginRight();
+            if (leftAuto || rightAuto)
+            {
+                var remaining = availableWidth - contentW - border.Left - border.Right - padding.Left - padding.Right;
+                if (leftAuto && rightAuto) { margin.Left = margin.Right = MathF.Max(0, remaining / 2f); }
+                else if (leftAuto) { margin.Left = MathF.Max(0, remaining); }
+                else { margin.Right = MathF.Max(0, remaining); }
+            }
+        }
+
         var contentX = x + margin.Left + border.Left + padding.Left;
         var contentY = y + margin.Top + border.Top + padding.Top;
 

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -1040,6 +1040,70 @@ internal static class BoxEngine
         return (left, Math.Max(0, right - left));
     }
 
+    /// <summary>The nearest float bottom strictly below <paramref name="y"/>, or null when no
+    /// float reaches past it — i.e. the next Y at which the available band can only get wider.</summary>
+    private static float? NextFloatBottom(List<ActiveFloat> floats, float y)
+    {
+        float? best = null;
+        foreach (var f in floats)
+            if (f.Bottom > y + 0.5f && (best is null || f.Bottom < best))
+                best = f.Bottom;
+        return best;
+    }
+
+    /// <summary>Width of the narrowest thing that must fit on the first line before it may be
+    /// shortened any further: the first atomic inline box, or the first word of the first text
+    /// item. Whitespace-only items are skipped — they are dropped at the start of a line.</summary>
+    private static float FirstUnbreakableWidth(List<InlineItem> items)
+    {
+        foreach (var item in items)
+        {
+            switch (item.Kind)
+            {
+                case InlineItemKind.OutOfFlow or InlineItemKind.LineBreak:
+                    continue;
+                case InlineItemKind.Text when item.Text is { } t:
+                    var trimmed = t.TrimStart();
+                    if (trimmed.Length == 0) continue;
+                    if (item.Node.GetWhiteSpace() is WhiteSpace.NoWrap or WhiteSpace.Pre) return item.Width;
+                    var end = trimmed.IndexOf(' ');
+                    var word = end < 0 ? trimmed : trimmed[..end];
+                    using (var font = TextMeasure.CreateFont(item.Node))
+                        return font.MeasureText(word);
+                default:
+                    return item.Width;
+            }
+        }
+        return 0f;
+    }
+
+    /// <summary>
+    /// The band (absolute left edge and width) of each successive line box of a wrapped text run
+    /// starting at <paramref name="startY"/>, ending once no float reaches any lower — from there
+    /// on every line has the containing block's full width, which the last entry carries.
+    /// Returns null when no float shortens any of them.
+    /// </summary>
+    private static List<(float X, float Width)>? LineBandsFor(
+        List<ActiveFloat> floats, float startX, float startY, float lineHeight,
+        float contentX, float contentW, float firstLineWidth)
+    {
+        if (floats.Count == 0 || lineHeight <= 0f) return null;
+        var lowest = floats.Max(f => f.Bottom);
+        if (lowest <= startY + 0.5f) return null;
+
+        var bands = new List<(float X, float Width)> { (startX, firstLineWidth) };
+        var y = startY + lineHeight;
+        // Bounded by the lowest float, so this cannot run away on a tall block.
+        while (y < lowest && bands.Count < 512)
+        {
+            var (bx, bw) = AvailableBand(floats, y, lineHeight, contentX, contentW);
+            bands.Add((bx, bw));
+            y += lineHeight;
+        }
+        bands.Add((contentX, contentW));   // below every float: the full band
+        return bands;
+    }
+
     /// <summary>Remove floats whose bottom edge is at or above <paramref name="y"/>.</summary>
     private static void RetireFloats(List<ActiveFloat> floats, float y)
     {
@@ -1436,10 +1500,23 @@ internal static class BoxEngine
 
         // The band available to the line under construction, as offsets from originX. Recomputed
         // for every line: a float only shortens the lines it is actually beside (§9.5).
+        var lineY = 0f;
+
+        // §9.5 rule 7: "if a shortened line box is too small to contain any content, it is shifted
+        // downward until either it fits or there are no more floats present". Without this an
+        // unbreakable word simply overflowed the narrow band beside the float.
+        var firstContentW = FirstUnbreakableWidth(items);
+        while (firstContentW > firstW + 0.5f)
+        {
+            var drop = NextFloatBottom(floats, originY + lineY);
+            if (drop is not { } nextY) break;
+            lineY = nextY - originY;
+            (firstX, firstW) = AvailableBand(floats, originY + lineY, 1, originX, maxWidth);
+        }
+
         var bandLeft = firstX - originX;
         var bandRight = bandLeft + firstW;
         var lineX = bandLeft;
-        var lineY = 0f;
 
         // Running CSS 2.1 §10.8.1 baseline-alignment accumulators for the line under construction:
         // maxAbove/maxBelow track the tallest reach above/below the shared baseline among items
@@ -1557,10 +1634,19 @@ internal static class BoxEngine
                     using var font = TextMeasure.CreateFont(item.Node);
                     var ws = item.Node.GetWhiteSpace();
                     var lh = item.Node.GetLineHeight(item.Node.GetFontSize());
-                    var wrapLines = TextMeasure.WrapText(item.Text, Math.Max(availW, 1f), font, ws, lh);
+                    // The paragraph wraps line by line against the band each line actually has:
+                    // beside a float the first lines are narrow and the ones below it are not.
+                    var bands = LineBandsFor(floats, originX + lineX, originY + lineY, lh,
+                                             originX, maxWidth, availW);
+                    var wrapLines = TextMeasure.WrapText(item.Text, Math.Max(availW, 1f), font, ws, lh,
+                                                         bands?.Select(b => b.Width).ToList());
                     var wrappedH = wrapLines.Sum(l => l.Height);
-                    effectiveItem = item with { Width = availW, Height = wrappedH, ContentW = availW, ContentH = wrappedH };
+                    var usedW = wrapLines.Count > 0 ? wrapLines.Max(l => l.Width) : availW;
+                    item.Node.LineBands = bands;
+                    effectiveItem = item with { Width = Math.Max(availW, usedW), Height = wrappedH,
+                                                ContentW = availW, ContentH = wrappedH };
                 }
+                else item.Node.LineBands = null;
             }
 
             var va = effectiveItem.Node.GetVerticalAlign();

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -366,6 +366,14 @@ internal static class BoxEngine
     /// </summary>
     private static void NormalizeTableBoxes(LayoutNode node)
     {
+        // Anonymous boxes are a FUNCTION of the current display values, so a pass that only ever
+        // adds wrappers cannot track a change to one. `t.style.display = 'none'` made the engine
+        // wrap that cell in an anonymous cell + table (a display:none box is not a proper table
+        // child), and restoring 'table-cell' left the wrappers in place — the cell stayed nested
+        // in a table of its own. Dropping the previously generated boxes first makes each pass
+        // rebuild them from the element tree, so normalization tracks the DOM.
+        UnwrapGeneratedTableBoxes(node);
+
         foreach (var child in node.Children)
             NormalizeTableBoxes(child);
 
@@ -386,6 +394,28 @@ internal static class BoxEngine
             // Everything else is not a table container, so any internal table box among its
             // children is missing its ancestors (§17.2.1 "generate missing parents").
             WrapMisparentedTableBoxes(node);
+        }
+    }
+
+    /// <summary>Replaces this node's previously generated anonymous table boxes with their own
+    /// children, in place, so the next pass regenerates them from the current display values.
+    /// Only the boxes this engine synthesized (<c>#anon-…</c>) are dissolved; real elements and
+    /// the text nodes migrated into them are kept exactly where they are.</summary>
+    private static void UnwrapGeneratedTableBoxes(LayoutNode node)
+    {
+        for (var i = node.Children.Count - 1; i >= 0; i--)
+        {
+            var child = node.Children[i];
+            if (!child.TagName.StartsWith("#anon-", StringComparison.Ordinal)) continue;
+
+            UnwrapGeneratedTableBoxes(child);      // dissolve inside-out
+            node.Children.RemoveAt(i);
+            for (var j = child.Children.Count - 1; j >= 0; j--)
+            {
+                var grandChild = child.Children[j];
+                grandChild.Parent = node;
+                node.Children.Insert(i, grandChild);
+            }
         }
     }
 

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -703,16 +703,20 @@ internal static class BoxEngine
         var padding = node.GetPadding(availableWidth, viewportHeight, fontSize);
         var border = node.GetBorderWidth();
 
-        // Explicit width or fill available (pass size=0 so unset width returns 0, not fontSize)
-        var explicitW = node.GetWidth(availableWidth);
+        // Explicit width or fill available (pass size=0 so unset width returns 0, not fontSize).
+        // "Specified" is IsAutoWidth, not "> 0": 'width: 0' is a used width of zero, and reading it
+        // as auto made a zero-width box fill its container instead.
+        var hasExplicitW = !node.IsAutoWidth();
+        var explicitW = hasExplicitW ? node.GetWidth(availableWidth) : 0f;
         // A block-level replaced box is sized from the image (§10.3.4 defers to §10.3.2's rules),
         // so its used width behaves like an explicit one for centering and box-sizing purposes.
         var replaced = TryResolveReplacedSize(node, availableWidth, parentContentHeight, viewportHeight);
+        var hasUsedW = replaced.HasValue || hasExplicitW;
         var usedW = replaced?.Width ?? explicitW;
-        var boxWidth = usedW > 0 ? usedW : availableWidth - margin.Left - margin.Right;
+        var boxWidth = hasUsedW ? usedW : availableWidth - margin.Left - margin.Right;
 
         // margin: auto centering — when the used width is known and one or both horizontal margins are auto
-        if (usedW > 0)
+        if (hasUsedW)
         {
             var leftAuto = node.IsAutoMarginLeft();
             var rightAuto = node.IsAutoMarginRight();
@@ -729,7 +733,7 @@ internal static class BoxEngine
         // padding/border are added outside it. Only border-box (and the auto/fill case) subtracts
         // padding+border from the box width. (Height already honors this below.)
         var isBorderBoxW = node.Style.GetPropertyValueSafe("box-sizing") == "border-box";
-        var contentW = (usedW > 0 && !isBorderBoxW)
+        var contentW = (hasUsedW && !isBorderBoxW)
             ? Math.Max(0f, usedW)
             : Math.Max(0f, boxWidth - border.Left - border.Right - padding.Left - padding.Right);
         var contentX = x + margin.Left + border.Left + padding.Left;
@@ -737,15 +741,16 @@ internal static class BoxEngine
 
         // A block-level table with auto width shrink-wraps to its content (CSS 2.1 §17.5.2), unlike
         // a normal block which fills its container. An explicit width already flowed into contentW.
-        if (explicitW <= 0 && node.GetDisplay() == DisplayType.Table)
+        if (!hasExplicitW && node.GetDisplay() == DisplayType.Table)
             contentW = TableEngine.MeasureTableWidth(node, contentW, viewportWidth, viewportHeight);
 
         // Resolve this node's explicit height using parentContentHeight for % and viewportHeight for vh/vw.
         // height:auto is content-based — GetHeight returns the containing-block height for auto (the
         // width-style "fill" behaviour of GetSize), which must NOT be treated as an explicit height.
         var isBorderBox = node.Style.GetPropertyValueSafe("box-sizing") == "border-box";
-        var explicitH = node.IsAutoHeight() ? 0f : node.GetHeight(parentContentHeight, 0, viewportHeight);
-        var knownContentH = explicitH > 0
+        var hasExplicitH = !node.IsAutoHeight();
+        var explicitH = hasExplicitH ? node.GetHeight(parentContentHeight, 0, viewportHeight) : 0f;
+        var knownContentH = hasExplicitH
             ? (isBorderBox ? Math.Max(0f, explicitH - border.Top - border.Bottom - padding.Top - padding.Bottom) : explicitH)
             : 0f;
 
@@ -790,7 +795,7 @@ internal static class BoxEngine
             contentH += trailingMargin;
 
         // Explicit height overrides — respect box-sizing: border-box
-        if (explicitH > 0)
+        if (hasExplicitH)
         {
             var clampedH = isBorderBox
                 ? Math.Max(0f, explicitH - border.Top - border.Bottom - padding.Top - padding.Bottom)

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -1913,6 +1913,12 @@ internal static class BoxEngine
 
         if (node.IsBrokenAroundBlock()) return (0f, 0f);
 
+        // §9.4.2's bidi box model puts the box's edges on its START and END fragments, which under
+        // 'direction: rtl' are its right and left sides. Lines here are always laid out
+        // left-to-right, so there is nowhere correct to put them; reserving the LTR pair would
+        // move the content the wrong way rather than leave it where it already is.
+        if (node.GetDirection() == "rtl") return (0f, 0f);
+
         var fontSize = node.GetFontSize();
         var margin = node.GetMargin(maxWidth, viewportHeight, fontSize);
         var padding = node.GetPadding(maxWidth, viewportHeight, fontSize);

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -562,8 +562,10 @@ internal static class BoxEngine
         var bottom = node.GetOffsetBottom(cbRect.Height, fontSize);
         var left = node.GetOffsetLeft(cbRect.Width, fontSize);
 
-        // Resolve width
-        var explicitW = node.GetWidth(cbRect.Width);
+        // Resolve width. An absolutely positioned replaced box takes its size from the image
+        // (§10.3.7's shrink-to-fit and the children-derived height below never see it).
+        var replaced = TryResolveReplacedSize(node, cbRect.Width, cbRect.Height, viewportHeight);
+        var explicitW = replaced?.Width ?? node.GetWidth(cbRect.Width);
         float contentW;
         if (explicitW > 0)
             contentW = explicitW;
@@ -578,6 +580,9 @@ internal static class BoxEngine
                        - border.Left - border.Right - padding.Left - padding.Right;
             if (!float.IsNaN(left)) availW -= left;
             else if (!float.IsNaN(right)) availW -= right;
+            // Both offsets auto: the box starts at its static position, so only what is left of
+            // the containing block from there is available to it (§10.3.7 rule 3).
+            else if (node.StaticX is { } sx) availW -= Math.Max(0f, sx - cbRect.Left);
             contentW = IntrinsicSizer.ShrinkToFit(node, Math.Max(0f, availW), viewportHeight);
         }
 
@@ -586,14 +591,14 @@ internal static class BoxEngine
         contentW = Math.Min(contentW, node.GetMaxWidth(cbRect.Width, fontSize));
         contentW = Math.Max(contentW, node.GetMinWidth(cbRect.Width, fontSize));
 
-        // Resolve X — §4.1: use FlexStaticX as static position when left/right are both auto
+        // Resolve X — §4.1: use StaticX as static position when left/right are both auto
         float contentX;
         if (!float.IsNaN(left))
             contentX = cbRect.Left + left + margin.Left + border.Left + padding.Left;
         else if (!float.IsNaN(right))
             contentX = cbRect.Right - right - margin.Right - border.Right - padding.Right - contentW;
-        else if (node.FlexStaticX.HasValue)
-            contentX = node.FlexStaticX.Value + margin.Left + border.Left + padding.Left;
+        else if (node.StaticX.HasValue)
+            contentX = node.StaticX.Value + margin.Left + border.Left + padding.Left;
         else
             contentX = cbRect.Left + margin.Left + border.Left + padding.Left;
 
@@ -638,20 +643,21 @@ internal static class BoxEngine
         }
         else if (autoHeight && !float.IsNaN(top) && !float.IsNaN(bottom))
             contentH = Math.Max(0, cbRect.Height - top - bottom - margin.Top - margin.Bottom - border.Top - border.Bottom - padding.Top - padding.Bottom);
+        if (replaced.HasValue) contentH = replaced.Value.Height;
 
         // Clamp to min/max-height (§10.7) — min wins over max (Acid2's scalp: min-height:1em
         // overrides max-height:2mm).
         contentH = Math.Min(contentH, node.GetMaxHeight(cbRect.Height, fontSize));
         contentH = Math.Max(contentH, node.GetMinHeight(cbRect.Height, fontSize));
 
-        // Resolve Y — §4.1: use FlexStaticY as static position when top/bottom are both auto
+        // Resolve Y — §4.1: use StaticY as static position when top/bottom are both auto
         float contentY;
         if (!float.IsNaN(top))
             contentY = cbRect.Top + top + margin.Top + border.Top + padding.Top;
         else if (!float.IsNaN(bottom))
             contentY = cbRect.Bottom - bottom - margin.Bottom - border.Bottom - padding.Bottom - contentH;
-        else if (node.FlexStaticY.HasValue)
-            contentY = node.FlexStaticY.Value + margin.Top + border.Top + padding.Top;
+        else if (node.StaticY.HasValue)
+            contentY = node.StaticY.Value + margin.Top + border.Top + padding.Top;
         else
             contentY = cbRect.Top + margin.Top + border.Top + padding.Top;
 
@@ -699,16 +705,20 @@ internal static class BoxEngine
 
         // Explicit width or fill available (pass size=0 so unset width returns 0, not fontSize)
         var explicitW = node.GetWidth(availableWidth);
-        var boxWidth = explicitW > 0 ? explicitW : availableWidth - margin.Left - margin.Right;
+        // A block-level replaced box is sized from the image (§10.3.4 defers to §10.3.2's rules),
+        // so its used width behaves like an explicit one for centering and box-sizing purposes.
+        var replaced = TryResolveReplacedSize(node, availableWidth, parentContentHeight, viewportHeight);
+        var usedW = replaced?.Width ?? explicitW;
+        var boxWidth = usedW > 0 ? usedW : availableWidth - margin.Left - margin.Right;
 
-        // margin: auto centering — when explicit width is set and one or both horizontal margins are auto
-        if (explicitW > 0)
+        // margin: auto centering — when the used width is known and one or both horizontal margins are auto
+        if (usedW > 0)
         {
             var leftAuto = node.IsAutoMarginLeft();
             var rightAuto = node.IsAutoMarginRight();
             if (leftAuto || rightAuto)
             {
-                var remaining = availableWidth - explicitW - border.Left - border.Right - padding.Left - padding.Right;
+                var remaining = availableWidth - usedW - border.Left - border.Right - padding.Left - padding.Right;
                 if (leftAuto && rightAuto) { margin.Left = margin.Right = MathF.Max(0, remaining / 2f); }
                 else if (leftAuto) { margin.Left = MathF.Max(0, remaining); }
                 else { margin.Right = MathF.Max(0, remaining); }
@@ -719,8 +729,8 @@ internal static class BoxEngine
         // padding/border are added outside it. Only border-box (and the auto/fill case) subtracts
         // padding+border from the box width. (Height already honors this below.)
         var isBorderBoxW = node.Style.GetPropertyValueSafe("box-sizing") == "border-box";
-        var contentW = (explicitW > 0 && !isBorderBoxW)
-            ? Math.Max(0f, explicitW)
+        var contentW = (usedW > 0 && !isBorderBoxW)
+            ? Math.Max(0f, usedW)
             : Math.Max(0f, boxWidth - border.Left - border.Right - padding.Left - padding.Right);
         var contentX = x + margin.Left + border.Left + padding.Left;
         var contentY = y + margin.Top + border.Top + padding.Top;
@@ -812,6 +822,10 @@ internal static class BoxEngine
             node.ScrollState = null;
         }
 
+        // A replaced box's height is the image's (or the ratio-derived) one — it has no in-flow
+        // content to measure, so the child/text-derived height above does not apply to it.
+        if (replaced.HasValue) contentH = replaced.Value.Height;
+
         // CSS 2.1 §10.7: clamp the resolved height to min-height/max-height. Percentages resolve
         // against the containing block height; when that is auto (parentContentHeight == 0) an
         // unresolvable percentage max-height computes to 'none' and min-height to 0.
@@ -851,6 +865,35 @@ internal static class BoxEngine
     /// Vertical margins between adjacent block children are collapsed (CSS 2.1 §8.3.1).
     /// Returns total content height consumed.
     /// </summary>
+    /// <summary>
+    /// CSS 2.1 §10.3.2 / §10.6.2 — the used content size of a REPLACED box (an <c>&lt;img&gt;</c>,
+    /// or an <c>&lt;object&gt;</c> that decoded an image). An 'auto' dimension takes the intrinsic
+    /// one, and when only one of width/height is specified the other is derived from the intrinsic
+    /// ratio. Returns null for a non-replaced box, whose size comes from its content instead.
+    /// <para>Only the inline path used to consult the intrinsic size, so a replaced box that was
+    /// block-level, floated or absolutely positioned filled its container horizontally (or
+    /// shrink-to-fit) and collapsed to zero height — it has no children to measure. §9.7 makes a
+    /// floated or absolutely positioned image block-level, so all three paths need this.</para>
+    /// </summary>
+    internal static (float Width, float Height)? TryResolveReplacedSize(
+        LayoutNode node, float cbWidth, float cbHeight, float viewportHeight)
+    {
+        if (node.TagName != "IMG" && !(node.TagName == "OBJECT" && node.Image != null)) return null;
+
+        // The width/height content attributes are captured as the intrinsic size (Parser), so this
+        // covers both a real bitmap and an attribute-declared size; CSS width/height still wins.
+        float iw = node.IntrinsicWidth > 0 ? node.IntrinsicWidth : node.Image?.Width ?? 0f;
+        float ih = node.IntrinsicHeight > 0 ? node.IntrinsicHeight : node.Image?.Height ?? 0f;
+
+        var specW = node.GetWidth(cbWidth);
+        var specH = node.IsAutoHeight() ? 0f : node.GetHeight(cbHeight, 0, viewportHeight);
+
+        if (specW > 0 && specH > 0) return (specW, specH);
+        if (specW > 0) return (specW, iw > 0 && ih > 0 ? specW * ih / iw : ih);
+        if (specH > 0) return (iw > 0 && ih > 0 ? specH * iw / ih : iw, specH);
+        return (iw, ih);
+    }
+
     /// <summary>Exposed for FlexEngine to lay out flex item children.</summary>
     internal static float LayoutChildrenPublic(
         List<LayoutNode> children,
@@ -1001,11 +1044,14 @@ internal static class BoxEngine
     /// <summary>
     /// Lays out a single floated child (shrink-to-fit width) and returns the ActiveFloat descriptor.
     /// </summary>
+    /// <param name="openLineY">Top of the line box the float would join (NaN when none is open),
+    /// with <paramref name="openLineUsedW"/> the width its content already occupies.</param>
     private static ActiveFloat LayoutFloat(
         LayoutNode child, FloatType side,
         List<ActiveFloat> floats,
         float contentX, float cursorY, float contentW,
-        float viewportWidth, float viewportHeight, float parentContentHeight)
+        float viewportWidth, float viewportHeight, float parentContentHeight,
+        float openLineY = float.NaN, float openLineUsedW = 0f)
     {
         var fontSize = child.GetFontSize();
         var margin = child.GetMargin(contentW, viewportHeight, fontSize);
@@ -1014,6 +1060,10 @@ internal static class BoxEngine
 
         // Shrink-to-fit: use explicit width or half container as heuristic
         var explicitW = child.GetWidth(contentW);
+        // A floated replaced box (§9.7 makes it block-level) is sized from the image, not
+        // shrink-to-fit over children it does not have.
+        var replaced = TryResolveReplacedSize(child, contentW, parentContentHeight, viewportHeight);
+        if (replaced.HasValue) explicitW = replaced.Value.Width;
         var maxAvail = contentW - margin.Left - margin.Right - border.Left - border.Right - padding.Left - padding.Right;
         float childContentW;
         if (explicitW > 0)
@@ -1034,6 +1084,16 @@ internal static class BoxEngine
 
         // Find placement Y — must not overlap existing floats on the same side
         var placeY = cursorY;
+
+        // CSS 2.1 §9.5.1 (rules 5-6): the top of a float is aligned with the top of the CURRENT
+        // line box — a float written after inline content sits beside that content, and only drops
+        // below the line when it no longer fits there (rule 7). Without this, `text <img
+        // style="float:right">` pushed the image onto its own line under the text.
+        if (!float.IsNaN(openLineY) && openLineY < placeY)
+        {
+            var (lbx, lbw) = AvailableBand(floats, openLineY, 1, contentX, contentW);
+            if (outerW <= lbw - openLineUsedW + 0.5f) placeY = openLineY;
+        }
         // Determine X based on side, respecting existing floats
         float placeContentX;
         // Try to place; if it doesn't fit, slide down
@@ -1088,6 +1148,7 @@ internal static class BoxEngine
             childContentH = isBorderBox
                 ? Math.Max(0, explicitH - border.Top - border.Bottom - padding.Top - padding.Bottom)
                 : explicitH;
+        if (replaced.HasValue) childContentH = replaced.Value.Height;
 
         child.Box = new BoxDimensions
         {
@@ -1154,6 +1215,10 @@ internal static class BoxEngine
         var pendingMargin = 0f;
         var firstBlockSeen = false;
         var lastPlacedWasBlock = false;
+        // The line box a following float may join (§9.5.1): NaN once a block-level box has been
+        // placed, since there is then no open line.
+        var openLineY = float.NaN;
+        var openLineUsedW = 0f;
         var i = 0;
 
         while (i < children.Count)
@@ -1168,10 +1233,18 @@ internal static class BoxEngine
                 continue;
             }
 
-            // Absolute/fixed elements are removed from normal flow
+            // Absolute/fixed elements are removed from normal flow, but the flow position they
+            // WOULD have taken is their static position (§10.3.7 / §10.6.4) — the used value of
+            // an 'auto' left/top. It is the current flow point: after the preceding in-flow
+            // content (including the margin still collapsing below it), at the left edge of the
+            // band left free by any floats there.
             var pos = child.GetPosition();
             if (pos == PositionType.Absolute || pos == PositionType.Fixed)
             {
+                var staticY = runY + pendingMargin;
+                var (staticBandX, _) = AvailableBand(floats, staticY, 1, contentX, contentW);
+                child.StaticX = staticBandX;
+                child.StaticY = staticY;
                 i++;
                 continue;
             }
@@ -1200,7 +1273,8 @@ internal static class BoxEngine
             if (floatSide != FloatType.None)
             {
                 var af = LayoutFloat(child, floatSide, floats, contentX, runY + pendingMargin, contentW,
-                                     viewportWidth, viewportHeight, parentContentHeight);
+                                     viewportWidth, viewportHeight, parentContentHeight,
+                                     openLineY, openLineUsedW);
                 floats.Add(af);
                 i++;
                 continue;
@@ -1251,6 +1325,7 @@ internal static class BoxEngine
                     pendingMargin = childBottomMargin;
                 }
                 lastPlacedWasBlock = true;
+                openLineY = float.NaN; // a block-level box closes any open line box
                 i++;
             }
             else
@@ -1264,8 +1339,17 @@ internal static class BoxEngine
                 while (i < children.Count)
                 {
                     var d = children[i].GetDisplay();
-                    if (d == DisplayType.Block || d == DisplayType.ListItem || d == DisplayType.Flex || d == DisplayType.Table) break;
-                    if (children[i].TagName != "#text" && children[i].GetFloat() != FloatType.None) break;
+                    // An out-of-flow box mid-run neither ends the line nor takes part in it: it
+                    // stays in the run so the line it sits on is its static position, and so the
+                    // inline content around it is not split onto two lines. (§9.7 blockifies it,
+                    // so this test must precede the block-level one.)
+                    var childPos = children[i].GetPosition();
+                    var outOfFlow = childPos == PositionType.Absolute || childPos == PositionType.Fixed;
+                    if (!outOfFlow)
+                    {
+                        if (d == DisplayType.Block || d == DisplayType.ListItem || d == DisplayType.Flex || d == DisplayType.Table) break;
+                        if (children[i].TagName != "#text" && children[i].GetFloat() != FloatType.None) break;
+                    }
                     run.Add(children[i]);
                     i++;
                 }
@@ -1278,8 +1362,12 @@ internal static class BoxEngine
                 // line box) and lays out at the committed position.
                 runY += pendingMargin;
                 pendingMargin = 0f;
-                var (effX, effW) = AvailableBand(floats, runY, 1, contentX, contentW);
-                var runH = LayoutInlineRun(run, effX, runY, effW, viewportWidth, viewportHeight);
+                var runH = LayoutInlineRun(run, contentX, runY, contentW, viewportWidth, viewportHeight,
+                                           floats, out var lastLineTop, out var lastLineWidth);
+                // Remember where the run's last line box sits: a float that comes right after it
+                // belongs ON that line, not below it (§9.5.1).
+                openLineY = runY + lastLineTop;
+                openLineUsedW = lastLineWidth;
                 runY += runH;
                 lastPlacedWasBlock = false;
             }
@@ -1305,19 +1393,47 @@ internal static class BoxEngine
     /// <summary>
     /// Lays out a run of inline/inline-block nodes within a line box.
     /// Returns total height consumed by all line boxes.
+    /// <para>CSS 2.1 §9.5: floats shorten the line boxes they are beside, and each line box gets
+    /// its own band — a float that ends partway down the run stops narrowing the lines below it,
+    /// which is how text flows around a float. <paramref name="floats"/> is the block formatting
+    /// context's active-float list and <paramref name="originX"/>/<paramref name="maxWidth"/>
+    /// the containing block's full content band; the band actually available is recomputed for
+    /// every line.</para>
     /// </summary>
+    /// <param name="lastLineTop">Offset from <paramref name="originY"/> to the top of the LAST line
+    /// box this run produced, and <paramref name="lastLineWidth"/> the width its content used.
+    /// A float that follows this run belongs on that line if it still fits (CSS 2.1 §9.5.1).</param>
     private static float LayoutInlineRun(
         List<LayoutNode> nodes,
         float originX, float originY,
         float maxWidth,
-        float viewportWidth, float viewportHeight)
+        float viewportWidth, float viewportHeight,
+        List<ActiveFloat> floats,
+        out float lastLineTop, out float lastLineWidth)
     {
+        lastLineTop = 0f;
+        lastLineWidth = 0f;
         var items = new List<InlineItem>();
-        CollectInlineItems(nodes, items, maxWidth, viewportWidth, viewportHeight);
+        // Items are measured against the first line's band; a line that turns out wider re-measures
+        // its text below.
+        var (firstX, firstW) = AvailableBand(floats, originY, 1, originX, maxWidth);
+        CollectInlineItems(nodes, items, firstW, viewportWidth, viewportHeight);
 
         if (items.Count == 0) return 0f;
 
-        var lineX = 0f;
+        // CSS 2.1 §16.2: 'text-align' aligns the inline-level content of each LINE BOX, not just
+        // text — an image, inline-block or inline-table on the line moves with it. It applies to
+        // block containers and is inherited, so the value that governs this run is the containing
+        // block's (an inline child may declare its own, which has no effect on the line box).
+        // 'justify' is handled at paint time by Drawer.DrawWrappedText and left alone here.
+        var container = nodes.Count > 0 ? nodes[0].Parent : null;
+        var lineAlign = (container ?? nodes[0]).GetTextAlign();
+
+        // The band available to the line under construction, as offsets from originX. Recomputed
+        // for every line: a float only shortens the lines it is actually beside (§9.5).
+        var bandLeft = firstX - originX;
+        var bandRight = bandLeft + firstW;
+        var lineX = bandLeft;
         var lineY = 0f;
 
         // Running CSS 2.1 §10.8.1 baseline-alignment accumulators for the line under construction:
@@ -1332,6 +1448,11 @@ internal static class BoxEngine
         var placed = new List<(InlineItem item, float relX, float relY)>();
         var lineStart = 0;
 
+        // Locals rather than the out parameters directly: C# forbids touching an 'out' parameter
+        // from inside a local function.
+        var committedLineTop = 0f;
+        var committedLineWidth = 0f;
+
         void CommitLine()
         {
             // Resolve the final line-box height: start from the baseline-aligned items' reach,
@@ -1342,21 +1463,52 @@ internal static class BoxEngine
             if (maxBottomH > above + below) above = maxBottomH - below;
             var thisLineHeight = above + below > 0f ? above + below : Math.Max(maxTopH, maxBottomH);
 
+            // The line's used width, ignoring trailing collapsible whitespace — it is removed at
+            // the end of a line (§16.6.1), so counting it would land a right-aligned line a space
+            // short and would overstate how much room a following float needs.
+            var lineRight = 0f;
+            for (var k = placed.Count - 1; k >= lineStart; k--)
+            {
+                var (it, rx, _) = placed[k];
+                if (it.Kind == InlineItemKind.OutOfFlow) continue;
+                if (it.Kind is InlineItemKind.Text or InlineItemKind.LineBreak &&
+                    string.IsNullOrWhiteSpace(it.Text)) continue;
+                lineRight = rx + it.Width;
+                break;
+            }
+            committedLineTop = lineY;
+            // Reported to the caller as the width used WITHIN the line's band, so it can decide
+            // whether a following float still fits on that line.
+            committedLineWidth = Math.Max(0f, lineRight - bandLeft);
+
+            // §16.2 horizontal alignment: shift the whole line by the space left unused in ITS
+            // band (which floats may have narrowed), not in the containing block.
+            var dx = 0f;
+            if (lineAlign is TextAlign.Center or TextAlign.Right)
+            {
+                var slack = bandRight - lineRight;
+                if (slack > 0f) dx = lineAlign == TextAlign.Center ? slack / 2f : slack;
+            }
+
             for (var k = lineStart; k < placed.Count; k++)
             {
                 var (it, rx, _) = placed[k];
                 var vAlign = it.Node.GetVerticalAlign();
-                float yOffset = vAlign switch
+                float yOffset = it.Kind == InlineItemKind.OutOfFlow ? 0f : vAlign switch
                 {
                     VerticalAlignType.Top or VerticalAlignType.TextTop => 0f,
                     VerticalAlignType.Bottom or VerticalAlignType.TextBottom => thisLineHeight - it.Height,
                     _ => above - AboveBaselineComponent(it, vAlign),
                 };
-                placed[k] = (it, rx, lineY + yOffset);
+                placed[k] = (it, rx + dx, lineY + yOffset);
             }
             lineY += thisLineHeight;
             maxAbove = maxBelow = maxTopH = maxBottomH = 0f;
-            lineX = 0f;
+            // The next line sits lower, so it may clear a float the previous line was beside.
+            var (nx, nw) = AvailableBand(floats, originY + lineY, 1, originX, maxWidth);
+            bandLeft = nx - originX;
+            bandRight = bandLeft + nw;
+            lineX = bandLeft;
             lineStart = placed.Count;
         }
 
@@ -1374,11 +1526,19 @@ internal static class BoxEngine
                 continue;
             }
 
-            if (lineX > 0 && lineX + item.Width > maxWidth)
+            // An out-of-flow marker takes no space and must not contribute to the line's height
+            // or its used width: it only records where the line had got to.
+            if (item.Kind == InlineItemKind.OutOfFlow)
+            {
+                placed.Add((item, lineX, lineY));
+                continue;
+            }
+
+            if (lineX > bandLeft && lineX + item.Width > bandRight)
                 CommitLine();
 
             // Skip whitespace-only text at the start of a line
-            if (lineX == 0 && item.Kind == InlineItemKind.Text &&
+            if (lineX <= bandLeft && item.Kind == InlineItemKind.Text &&
                 item.Text != null && item.Text.Trim().Length == 0)
                 continue;
 
@@ -1386,7 +1546,7 @@ internal static class BoxEngine
             var effectiveItem = item;
             if (item.Kind == InlineItemKind.Text && item.Text != null)
             {
-                var availW = maxWidth - lineX;
+                var availW = bandRight - lineX;
                 if (availW > 0 && item.Width > availW)
                 {
                     using var font = TextMeasure.CreateFont(item.Node);
@@ -1423,6 +1583,8 @@ internal static class BoxEngine
             ApplyInlineItem(item, originX + relX, originY + relY, viewportWidth, viewportHeight);
         }
 
+        lastLineTop = committedLineTop;
+        lastLineWidth = committedLineWidth;
         return lineY;
     }
 
@@ -1459,9 +1621,16 @@ internal static class BoxEngine
             var display = node.GetDisplay();
             if (display == DisplayType.None) continue;
 
-            // Absolute/fixed are out of flow — skip in inline runs
+            // Absolute/fixed are out of flow: they add nothing to the line, but a zero-sized
+            // marker rides along so the line box position they would have occupied is recorded
+            // as their static position (§10.3.7 / §10.6.4).
             var nodePos = node.GetPosition();
-            if (nodePos == PositionType.Absolute || nodePos == PositionType.Fixed) continue;
+            if (nodePos == PositionType.Absolute || nodePos == PositionType.Fixed)
+            {
+                items.Add(new InlineItem(InlineItemKind.OutOfFlow, node, null, 0, 0,
+                           default, default, default, 0, 0, 0));
+                continue;
+            }
 
             // <br> → forced line break item
             if (node.TagName == "BR")
@@ -1730,6 +1899,13 @@ internal static class BoxEngine
                     FlexEngine.LayoutFlex(node, contentX, contentY, item.ContentW, item.ContentH, 0, 0);
                     break;
                 }
+            case InlineItemKind.OutOfFlow:
+                {
+                    // Records only — the box itself is laid out later by the positioned pass.
+                    node.StaticX = absX;
+                    node.StaticY = absY;
+                    break;
+                }
             case InlineItemKind.Image:
             case InlineItemKind.Text:
             case InlineItemKind.LineBreak:
@@ -1747,7 +1923,10 @@ internal static class BoxEngine
     // Inline item model
     // -------------------------------------------------------------------------
 
-    private enum InlineItemKind { Text, Image, InlineBlock, InlineFlex, InlineTable, LineBreak }
+    /// <summary><see cref="OutOfFlow"/> is a zero-sized marker for an absolutely positioned box
+    /// met inside an inline run: it occupies no space on the line but rides along with it, so the
+    /// line position it lands on is the box's static position (§10.3.7 / §10.6.4).</summary>
+    private enum InlineItemKind { Text, Image, InlineBlock, InlineFlex, InlineTable, LineBreak, OutOfFlow }
 
     /// <summary><see cref="Ascent"/> is the distance from this item's own top (margin edge) down
     /// to the baseline it should align on (CSS 2.1 §10.8). Text uses the font's half-leading

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -1913,9 +1913,29 @@ internal static class BoxEngine
             {
                 using var font = TextMeasure.CreateFont(node);
                 var lh = node.GetLineHeight(node.GetFontSize());
-                var (w, h, ascent) = TextMeasure.MeasureSingleLine(node.DisplayText, font, lh);
-                items.Add(new InlineItem(InlineItemKind.Text, node, node.DisplayText, w, h,
-                           default, default, default, w, h, ascent));
+                // 'letter-spacing' / 'word-spacing' widen the text the painter draws, so they have
+                // to widen the box layout reserves for it too — measuring without them put every
+                // following inline box in the wrong place.
+                var (ls, wsp) = TextMeasure.SpacingOf(node);
+
+                // §16.6: under pre / pre-wrap / pre-line a newline is a FORCED line break. An
+                // inline run measured the whole string as one unbroken item, so a preformatted
+                // <span> holding two lines drew them on top of each other.
+                var ws = node.GetWhiteSpace();
+                var segments = ws is WhiteSpace.Pre or WhiteSpace.PreWrap or WhiteSpace.PreLine
+                               && node.DisplayText.Contains('\n')
+                    ? node.DisplayText.Split('\n')
+                    : [node.DisplayText];
+
+                for (var si = 0; si < segments.Length; si++)
+                {
+                    if (si > 0)
+                        items.Add(new InlineItem(InlineItemKind.LineBreak, node, null, 0, lh,
+                                   default, default, default, 0, lh, TextMeasure.ComputeAscent(font, lh)));
+                    var (w, h, ascent) = TextMeasure.MeasureSingleLine(segments[si], font, lh, ls, wsp);
+                    items.Add(new InlineItem(InlineItemKind.Text, node, segments[si], w, h,
+                               default, default, default, w, h, ascent));
+                }
             }
             else if (node.Children.Count > 0)
             {

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -1651,6 +1651,29 @@ internal static class BoxEngine
         var maxBelow = 0f;
         var maxTopH = 0f;
         var maxBottomH = 0f;
+        // Whether anything on the current line aligns against the shared baseline. Only then does
+        // maxBelow hold a real measurement rather than its 0 starting value.
+        var hasBaselineItem = false;
+        var lineEndsWithBreak = false;
+
+        // §10.8.1's STRUT: every line box begins with a zero-width inline box carrying the block
+        // container's own font and line-height, so a line holding nothing but a 96px image is
+        // still at least as tall as the text that would have sat on its baseline. Measured once —
+        // the strut's metrics come from the block, not from whatever lands on the line.
+        var strutAbove = 0f;
+        var strutBelow = 0f;
+        if (container is not null)
+        {
+            using var strutFont = TextMeasure.CreateFont(container);
+            var strutLh = container.GetLineHeight(container.GetFontSize());
+            // With 'line-height: normal' the strut is exactly the font's own box — no leading to
+            // split. Our 'normal' is a flat 1.4em, which is generous enough that a strut using it
+            // would poke out above a 16px image on an otherwise-empty line and nudge it down.
+            if (container.IsNormalLineHeight())
+                strutLh = -strutFont.Metrics.Ascent + strutFont.Metrics.Descent;
+            strutAbove = TextMeasure.ComputeAscent(strutFont, strutLh);
+            strutBelow = strutLh - strutAbove;
+        }
 
         var placed = new List<(InlineItem item, float relX, float relY)>();
         var lineStart = 0;
@@ -1660,12 +1683,42 @@ internal static class BoxEngine
         var committedLineTop = 0f;
         var committedLineWidth = 0f;
 
+        // §9.4.2's test for a line box that "exists": any in-flow content at all — text that is
+        // not purely collapsible whitespace, a replaced box, an inline-block/flex/table, or a
+        // forced break.
+        bool LineHasContent()
+        {
+            if (lineEndsWithBreak) return true;
+            for (var k = lineStart; k < placed.Count; k++)
+            {
+                var it = placed[k].item;
+                if (it.Kind == InlineItemKind.OutOfFlow) continue;
+                if (it.Kind == InlineItemKind.Text && string.IsNullOrWhiteSpace(it.Text)) continue;
+                return true;
+            }
+            return false;
+        }
+
         void CommitLine()
         {
             // Resolve the final line-box height: start from the baseline-aligned items' reach,
             // then grow outward (below for 'top', above for 'bottom') if those need more room.
             var above = maxAbove;
             var below = maxBelow;
+
+            // The strut only counts on a line that actually has content. §9.4.2: a line box with
+            // no text, no in-flow content and no inline box with non-zero edges is a ZERO-height
+            // line box, so seeding the strut unconditionally would give every stray whitespace
+            // node a line of its own.
+            if (LineHasContent())
+            {
+                above = Math.Max(above, strutAbove);
+                // The strut's own reach below the baseline can be NEGATIVE (a line-height smaller
+                // than the font's ascent+descent gives negative half-leading), so it only counts
+                // when nothing else has claimed room down there — clamping it to 0 would stretch a
+                // `line-height: 10px` line back out to the full baseline.
+                below = hasBaselineItem ? Math.Max(below, strutBelow) : strutBelow;
+            }
             if (maxTopH > above + below) below = maxTopH - above;
             if (maxBottomH > above + below) above = maxBottomH - below;
             var thisLineHeight = above + below > 0f ? above + below : Math.Max(maxTopH, maxBottomH);
@@ -1711,6 +1764,8 @@ internal static class BoxEngine
             }
             lineY += thisLineHeight;
             maxAbove = maxBelow = maxTopH = maxBottomH = 0f;
+            hasBaselineItem = false;
+            lineEndsWithBreak = false;
             // The next line sits lower, so it may clear a float the previous line was beside.
             var (nx, nw) = AvailableBand(floats, originY + lineY, 1, originX, maxWidth);
             bandLeft = nx - originX;
@@ -1728,7 +1783,11 @@ internal static class BoxEngine
                 {
                     maxAbove = item.Ascent;
                     maxBelow = item.Height - item.Ascent;
+                    hasBaselineItem = true;
                 }
+                // §9.4.2 exempts a line that ends with a forced break from the zero-height rule,
+                // so an empty <br> line still gets the strut.
+                lineEndsWithBreak = true;
                 CommitLine();
                 continue;
             }
@@ -1786,6 +1845,7 @@ internal static class BoxEngine
                 default:
                     maxAbove = Math.Max(maxAbove, AboveBaselineComponent(effectiveItem, va));
                     maxBelow = Math.Max(maxBelow, effectiveItem.Height - AboveBaselineComponent(effectiveItem, va));
+                    hasBaselineItem = true;
                     break;
             }
 

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -414,6 +414,7 @@ internal static class BoxEngine
         {
             if (run.Count == 0) return;
             var anon = new LayoutNode(null, "#anon-table", "", node.Style);
+            anon.ResetNonInheritedStyles();
             anon.StyleOverrides["display"] = "table";
             foreach (var side in new[] { "top", "right", "bottom", "left" })
             {
@@ -496,6 +497,7 @@ internal static class BoxEngine
         {
             if (run.Count == 0) return;
             var anon = new LayoutNode(null, wrapAsRow ? "#anon-row" : "#anon-cell", "", parent.Style);
+            anon.ResetNonInheritedStyles();
             anon.StyleOverrides["display"] = wrapAsRow ? "table-row" : "table-cell";
             foreach (var side in new[] { "top", "right", "bottom", "left" })
             {

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -1185,7 +1185,7 @@ internal static class BoxEngine
         {
             switch (item.Kind)
             {
-                case InlineItemKind.OutOfFlow or InlineItemKind.LineBreak:
+                case InlineItemKind.OutOfFlow or InlineItemKind.LineBreak or InlineItemKind.InlineEdge:
                     continue;
                 case InlineItemKind.Text when item.Text is { } t:
                     var trimmed = t.TrimStart();
@@ -1833,6 +1833,15 @@ internal static class BoxEngine
                 else item.Node.LineBands = null;
             }
 
+            // §10.8: the vertical edges of a non-replaced inline box do not enter the line box's
+            // height calculation, so an edge spacer only advances the pen.
+            if (effectiveItem.Kind == InlineItemKind.InlineEdge)
+            {
+                placed.Add((effectiveItem, lineX, lineY));
+                lineX += effectiveItem.Width;
+                continue;
+            }
+
             var va = effectiveItem.Node.GetVerticalAlign();
             switch (va)
             {
@@ -1885,6 +1894,40 @@ internal static class BoxEngine
             VerticalAlignType.Super => item.Ascent + fontSize * 0.15f,
             _ => item.Ascent, // baseline
         };
+    }
+
+    private static InlineItem EdgeItem(LayoutNode node, float width) =>
+        new(InlineItemKind.InlineEdge, node, null, width, 0, default, default, default, width, 0, 0);
+
+    /// <summary>
+    /// CSS 2.1 §8.4: the HORIZONTAL margins and padding of a non-replaced inline box are laid out
+    /// — they push whatever follows along the line — while its vertical ones do not affect the
+    /// line box's height. Returns the widths to reserve before and after the box's own content.
+    /// <para>Borders are deliberately left out: the painter draws no border on an inline box, so
+    /// reserving room for one would open a gap with nothing in it.</para>
+    /// </summary>
+    private static (float Leading, float Trailing) InlineBoxEdges(
+        LayoutNode node, float maxWidth, float viewportHeight)
+    {
+        // Anonymous boxes (#text and friends) resolve their styles from the element they came
+        // from, so asking them for a margin would apply the parent's a second time.
+        if (node.TagName.StartsWith('#')) return (0f, 0f);
+
+        // §9.2.1.1: an inline box holding a block-level child is BROKEN AROUND it, and the edges
+        // belong to the first and last fragment only. Each fragment is a separate inline run here,
+        // so emitting the edges per run would repeat them on every piece.
+        foreach (var child in node.Children)
+            if (child.GetDisplay() is DisplayType.Block or DisplayType.Flex or DisplayType.Table
+                                    or DisplayType.ListItem)
+                return (0f, 0f);
+
+        var fontSize = node.GetFontSize();
+        var margin = node.GetMargin(maxWidth, viewportHeight, fontSize);
+        var padding = node.GetPadding(maxWidth, viewportHeight, fontSize);
+        // 'auto' is 0 on an inline box (§10.3.1), not the block-level centring rule.
+        var left = (node.IsAutoMarginLeft() ? 0f : margin.Left) + padding.Left;
+        var right = (node.IsAutoMarginRight() ? 0f : margin.Right) + padding.Right;
+        return (left, right);
     }
 
     /// <summary>
@@ -2109,6 +2152,8 @@ internal static class BoxEngine
                     ? node.DisplayText.Split('\n')
                     : [node.DisplayText];
 
+                var (leading, trailing) = InlineBoxEdges(node, maxWidth, viewportHeight);
+                if (leading != 0f) items.Add(EdgeItem(node, leading));
                 for (var si = 0; si < segments.Length; si++)
                 {
                     if (si > 0)
@@ -2118,10 +2163,14 @@ internal static class BoxEngine
                     items.Add(new InlineItem(InlineItemKind.Text, node, segments[si], w, h,
                                default, default, default, w, h, ascent));
                 }
+                if (trailing != 0f) items.Add(EdgeItem(node, trailing));
             }
             else if (node.Children.Count > 0)
             {
+                var (leading, trailing) = InlineBoxEdges(node, maxWidth, viewportHeight);
+                if (leading != 0f) items.Add(EdgeItem(node, leading));
                 CollectInlineItems(node.Children, items, maxWidth, viewportWidth, viewportHeight);
+                if (trailing != 0f) items.Add(EdgeItem(node, trailing));
             }
         }
     }
@@ -2232,6 +2281,10 @@ internal static class BoxEngine
                     node.StaticY = absY;
                     break;
                 }
+            case InlineItemKind.InlineEdge:
+                // Pure advance. The inline box's own painted geometry comes from the fragments its
+                // text children record, so writing a box here would overwrite it with a sliver.
+                break;
             case InlineItemKind.Image:
                 {
                     // The item spans the margin box; the node's own box starts inside the
@@ -2264,7 +2317,15 @@ internal static class BoxEngine
                         (node.InlineFragments ??= []).Add((rect, item.Text ?? ""));
                         if (node.InlineFragments.Count > 1) rect = SKRect.Union(node.Box.ContentBox, rect);
                     }
-                    node.Box = new BoxDimensions { ContentBox = rect };
+                    // The line already reserved this box's horizontal padding (§8.4), so record it
+                    // here too — the painter fills the PADDING box, and without it the background
+                    // would stop short of the space the line gave the box.
+                    node.Box = new BoxDimensions
+                    {
+                        ContentBox = rect,
+                        Padding = node.TagName.StartsWith('#')
+                            ? default : node.GetPadding(0, 0, node.GetFontSize()),
+                    };
                     break;
                 }
         }
@@ -2277,7 +2338,9 @@ internal static class BoxEngine
     /// <summary><see cref="OutOfFlow"/> is a zero-sized marker for an absolutely positioned box
     /// met inside an inline run: it occupies no space on the line but rides along with it, so the
     /// line position it lands on is the box's static position (§10.3.7 / §10.6.4).</summary>
-    private enum InlineItemKind { Text, Image, InlineBlock, InlineFlex, InlineTable, LineBreak, OutOfFlow }
+    /// <summary><see cref="InlineEdge"/> is the leading or trailing margin+border+padding of a
+    /// non-replaced inline box: it advances the line but has no height of its own (§8.4).</summary>
+    private enum InlineItemKind { Text, Image, InlineBlock, InlineFlex, InlineTable, LineBreak, OutOfFlow, InlineEdge }
 
     /// <summary><see cref="Ascent"/> is the distance from this item's own top (margin edge) down
     /// to the baseline it should align on (CSS 2.1 §10.8). Text uses the font's half-leading

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -437,6 +437,12 @@ internal static class BoxEngine
             if (IsMisparentedTableBox(c)) { anyMisparented = true; break; }
         if (!anyMisparented) return;
 
+        // §17.2.1: "If the box's parent is an inline box, generate an anonymous INLINE-table box;
+        // otherwise, an anonymous table box." A block-level table inside an inline box broke the
+        // line in two, so cells written between inline text — `a <span table-cell>b</span>c` —
+        // landed on their own line instead of flowing with it.
+        var inlineContext = node.GetDisplay() == DisplayType.Inline;
+
         var newChildren = new List<LayoutNode>();
         var run = new List<LayoutNode>();
 
@@ -445,7 +451,7 @@ internal static class BoxEngine
             if (run.Count == 0) return;
             var anon = new LayoutNode(null, "#anon-table", "", node.Style);
             anon.ResetNonInheritedStyles();
-            anon.StyleOverrides["display"] = "table";
+            anon.StyleOverrides["display"] = inlineContext ? "inline-table" : "table";
             foreach (var side in new[] { "top", "right", "bottom", "left" })
             {
                 anon.StyleOverrides[$"margin-{side}"] = "0";

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -1903,8 +1903,6 @@ internal static class BoxEngine
     /// CSS 2.1 §8.4: the HORIZONTAL margins and padding of a non-replaced inline box are laid out
     /// — they push whatever follows along the line — while its vertical ones do not affect the
     /// line box's height. Returns the widths to reserve before and after the box's own content.
-    /// <para>Borders are deliberately left out: the painter draws no border on an inline box, so
-    /// reserving room for one would open a gap with nothing in it.</para>
     /// </summary>
     private static (float Leading, float Trailing) InlineBoxEdges(
         LayoutNode node, float maxWidth, float viewportHeight)
@@ -1913,13 +1911,7 @@ internal static class BoxEngine
         // from, so asking them for a margin would apply the parent's a second time.
         if (node.TagName.StartsWith('#')) return (0f, 0f);
 
-        // §9.2.1.1: an inline box holding a block-level child is BROKEN AROUND it, and the edges
-        // belong to the first and last fragment only. Each fragment is a separate inline run here,
-        // so emitting the edges per run would repeat them on every piece.
-        foreach (var child in node.Children)
-            if (child.GetDisplay() is DisplayType.Block or DisplayType.Flex or DisplayType.Table
-                                    or DisplayType.ListItem)
-                return (0f, 0f);
+        if (node.IsBrokenAroundBlock()) return (0f, 0f);
 
         var fontSize = node.GetFontSize();
         var margin = node.GetMargin(maxWidth, viewportHeight, fontSize);
@@ -2319,12 +2311,14 @@ internal static class BoxEngine
                     }
                     // The line already reserved this box's horizontal padding (§8.4), so record it
                     // here too — the painter fills the PADDING box, and without it the background
-                    // would stop short of the space the line gave the box.
+                    // would stop short of the space the line gave the box. Anonymous boxes (#text)
+                    // resolve their styles from the element that produced them, so taking padding
+                    // there would apply the parent's a second time.
+                    var noEdges = node.TagName.StartsWith('#') || node.IsBrokenAroundBlock();
                     node.Box = new BoxDimensions
                     {
                         ContentBox = rect,
-                        Padding = node.TagName.StartsWith('#')
-                            ? default : node.GetPadding(0, 0, node.GetFontSize()),
+                        Padding = noEdges ? default : node.GetPadding(0, 0, node.GetFontSize()),
                     };
                     break;
                 }

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -593,12 +593,44 @@ internal static class BoxEngine
         contentW = Math.Min(contentW, node.GetMaxWidth(cbRect.Width, fontSize));
         contentW = Math.Max(contentW, node.GetMinWidth(cbRect.Width, fontSize));
 
-        // Resolve X — §4.1: use StaticX as static position when left/right are both auto
+        // §10.3.7: when 'left', 'width' and 'right' are all given, an auto margin absorbs the
+        // space left over — two of them split it equally, which is how an absolutely positioned
+        // box is centred in its containing block. Auto margins used to compute to zero, so such a
+        // box sat at its 'left' offset instead.
+        var isRtl = node.GetDirection() == "rtl";
+        if (!float.IsNaN(left) && !float.IsNaN(right))
+        {
+            var mlAuto = node.IsAutoMarginLeft();
+            var mrAuto = node.IsAutoMarginRight();
+            if (mlAuto || mrAuto)
+            {
+                // Whatever the containing block has left after the offsets, the box and any
+                // margin that is NOT auto — that remainder is what the auto margins take.
+                var slack = cbRect.Width - left - right - contentW
+                            - border.Left - border.Right - padding.Left - padding.Right
+                            - (mlAuto ? 0f : margin.Left) - (mrAuto ? 0f : margin.Right);
+                if (mlAuto && mrAuto)
+                {
+                    // A negative remainder is pushed entirely onto the end side (§10.3.7 rule 4).
+                    if (slack >= 0f) margin.Left = margin.Right = slack / 2f;
+                    else if (isRtl) { margin.Right = 0f; margin.Left = slack; }
+                    else { margin.Left = 0f; margin.Right = slack; }
+                }
+                else if (mlAuto) margin.Left = slack;
+                else margin.Right = slack;
+            }
+        }
+
+        // Resolve X — §10.3.7 rule 1: with 'left' and 'right' both auto the box takes its static
+        // position, which under 'direction: rtl' is measured from the RIGHT edge — the hypothetical
+        // static box sits at the end of the line, so an RTL containing block puts it flush right.
         float contentX;
         if (!float.IsNaN(left))
             contentX = cbRect.Left + left + margin.Left + border.Left + padding.Left;
         else if (!float.IsNaN(right))
             contentX = cbRect.Right - right - margin.Right - border.Right - padding.Right - contentW;
+        else if (isRtl)
+            contentX = cbRect.Right - margin.Right - border.Right - padding.Right - contentW;
         else if (node.StaticX.HasValue)
             contentX = node.StaticX.Value + margin.Left + border.Left + padding.Left;
         else
@@ -651,6 +683,27 @@ internal static class BoxEngine
         // overrides max-height:2mm).
         contentH = Math.Min(contentH, node.GetMaxHeight(cbRect.Height, fontSize));
         contentH = Math.Max(contentH, node.GetMinHeight(cbRect.Height, fontSize));
+
+        // §10.6.4: the vertical axis works the same way — with 'top', 'height' and 'bottom' all
+        // given, auto margins share out what is left, centring the box vertically.
+        if (!float.IsNaN(top) && !float.IsNaN(bottom))
+        {
+            var mtAuto = node.IsAutoMarginTop();
+            var mbAuto = node.IsAutoMarginBottom();
+            if (mtAuto || mbAuto)
+            {
+                var slack = cbRect.Height - top - bottom - contentH
+                            - border.Top - border.Bottom - padding.Top - padding.Bottom
+                            - (mtAuto ? 0f : margin.Top) - (mbAuto ? 0f : margin.Bottom);
+                if (mtAuto && mbAuto)
+                {
+                    if (slack >= 0f) margin.Top = margin.Bottom = slack / 2f;
+                    else { margin.Top = 0f; margin.Bottom = slack; }
+                }
+                else if (mtAuto) margin.Top = slack;
+                else margin.Bottom = slack;
+            }
+        }
 
         // Resolve Y — §4.1: use StaticY as static position when top/bottom are both auto
         float contentY;

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -2013,6 +2013,13 @@ internal static class BoxEngine
                 // meant `img { padding-right: 20px }` advanced the line by nothing at all.
                 var imgFontSize = node.GetFontSize();
                 var imgMargin = node.GetMargin(maxWidth, viewportHeight, imgFontSize);
+                // §10.3.2 / §10.6.2: on an INLINE replaced box every 'auto' margin has a used
+                // value of 0. GetMargin's 'auto' means "centre in the containing block", which is
+                // the block-level rule — applying it here pushed the image into mid-air.
+                if (node.IsAutoMarginTop()) imgMargin.Top = 0f;
+                if (node.IsAutoMarginBottom()) imgMargin.Bottom = 0f;
+                if (node.IsAutoMarginLeft()) imgMargin.Left = 0f;
+                if (node.IsAutoMarginRight()) imgMargin.Right = 0f;
                 var imgPadding = node.GetPadding(maxWidth, viewportHeight, imgFontSize);
                 var imgBorder = node.GetBorderWidth();
                 var imgW = imgMargin.Left + imgBorder.Left + imgPadding.Left + w

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -653,11 +653,21 @@ internal static class BoxEngine
         else
             selfContentH = 0f;
 
-        // Lay out children to get content height
+        // Lay out children to get content height. The formatting context is the box's OWN display,
+        // exactly as LayoutBlock dispatches it: an absolutely positioned table or flex container
+        // used to fall through to plain block-children layout, which flowed its rows and cells as
+        // inline content — an abs-pos <table> came out as one long wrapping line of cell text.
+        float LayoutAbsChildren(float originY, float knownH) => node.GetDisplay() switch
+        {
+            DisplayType.Flex or DisplayType.InlineFlex =>
+                FlexEngine.LayoutFlex(node, contentX, originY, contentW, knownH, viewportWidth, viewportHeight),
+            DisplayType.Table or DisplayType.InlineTable =>
+                TableEngine.LayoutTable(node, contentX, originY, contentW, viewportWidth, viewportHeight),
+            _ => LayoutChildren(node.Children, contentX, originY, contentW, viewportWidth, viewportHeight, knownH),
+        };
+
         var contentY0 = cbRect.Top; // temp origin for children layout
-        var contentH = LayoutChildren(node.Children,
-            contentX, contentY0,
-            contentW, viewportWidth, viewportHeight, selfContentH);
+        var contentH = LayoutAbsChildren(contentY0, selfContentH);
 
         if (contentH == 0 && !string.IsNullOrEmpty(node.DisplayText))
         {
@@ -718,7 +728,7 @@ internal static class BoxEngine
 
         // Re-layout children at the correct absolute Y
         if (contentY != contentY0)
-            LayoutChildren(node.Children, contentX, contentY, contentW, viewportWidth, viewportHeight);
+            LayoutAbsChildren(contentY, selfContentH);
 
         node.Box = new BoxDimensions
         {

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -1895,8 +1895,15 @@ internal static class BoxEngine
             }
             else if (node.TagName == "IMG" || (node.TagName == "OBJECT" && node.Image != null))
             {
-                var w = node.IntrinsicWidth > 0 ? (float)node.IntrinsicWidth : node.Image?.Width ?? 100f;
-                var h = node.IntrinsicHeight > 0 ? (float)node.IntrinsicHeight : node.Image?.Height ?? 100f;
+                // §10.3.2 / §10.6.2: a CSS 'width'/'height' on a replaced element overrides its
+                // intrinsic size, and one specified dimension derives the other from the intrinsic
+                // ratio. The inline path used to read the intrinsic size alone, so `width: 100%`
+                // (or the HTML width="100%" hint) left the image at its natural pixel width.
+                var sized = TryResolveReplacedSize(node, maxWidth, viewportHeight, viewportHeight);
+                var w = sized is { Width: > 0 } ? sized.Value.Width
+                        : node.IntrinsicWidth > 0 ? (float)node.IntrinsicWidth : node.Image?.Width ?? 100f;
+                var h = sized is { Height: > 0 } ? sized.Value.Height
+                        : node.IntrinsicHeight > 0 ? (float)node.IntrinsicHeight : node.Image?.Height ?? 100f;
                 // Replaced elements have no baseline of their own — CSS 2.1 §10.8's fallback rule
                 // aligns their bottom margin edge with the line's baseline (Ascent = full height).
                 items.Add(new InlineItem(InlineItemKind.Image, node, null, w, h,

--- a/Lite/Layout/BoxEngine.cs
+++ b/Lite/Layout/BoxEngine.cs
@@ -2007,10 +2007,22 @@ internal static class BoxEngine
                         : node.IntrinsicWidth > 0 ? (float)node.IntrinsicWidth : node.Image?.Width ?? 100f;
                 var h = sized is { Height: > 0 } ? sized.Value.Height
                         : node.IntrinsicHeight > 0 ? (float)node.IntrinsicHeight : node.Image?.Height ?? 100f;
+                // §8.4: an inline REPLACED box's margins, borders and padding all take part in
+                // layout horizontally *and* vertically — unlike a non-replaced inline box, whose
+                // vertical edges do not affect line height. Reserving only the content size here
+                // meant `img { padding-right: 20px }` advanced the line by nothing at all.
+                var imgFontSize = node.GetFontSize();
+                var imgMargin = node.GetMargin(maxWidth, viewportHeight, imgFontSize);
+                var imgPadding = node.GetPadding(maxWidth, viewportHeight, imgFontSize);
+                var imgBorder = node.GetBorderWidth();
+                var imgW = imgMargin.Left + imgBorder.Left + imgPadding.Left + w
+                         + imgPadding.Right + imgBorder.Right + imgMargin.Right;
+                var imgH = imgMargin.Top + imgBorder.Top + imgPadding.Top + h
+                         + imgPadding.Bottom + imgBorder.Bottom + imgMargin.Bottom;
                 // Replaced elements have no baseline of their own — CSS 2.1 §10.8's fallback rule
                 // aligns their bottom margin edge with the line's baseline (Ascent = full height).
-                items.Add(new InlineItem(InlineItemKind.Image, node, null, w, h,
-                           default, default, default, w, h, h));
+                items.Add(new InlineItem(InlineItemKind.Image, node, null, imgW, imgH,
+                           imgMargin, imgPadding, imgBorder, w, h, imgH));
             }
             else if (!string.IsNullOrEmpty(node.DisplayText) && !node.Children.Any())
             {
@@ -2154,6 +2166,25 @@ internal static class BoxEngine
                     break;
                 }
             case InlineItemKind.Image:
+                {
+                    // The item spans the margin box; the node's own box starts inside the
+                    // margin/border/padding edges so the bitmap lands on the content box and
+                    // the decorations get a padding/border box to paint against.
+                    var m = item.Margin;
+                    var p = item.Padding;
+                    var b = item.Border;
+                    var contentX = absX + m.Left + b.Left + p.Left;
+                    var contentY = absY + m.Top + b.Top + p.Top;
+                    node.Box = new BoxDimensions
+                    {
+                        ContentBox = new SKRect(contentX, contentY,
+                                                contentX + item.ContentW, contentY + item.ContentH),
+                        Margin = m,
+                        Padding = p,
+                        Border = b,
+                    };
+                    break;
+                }
             case InlineItemKind.Text:
             case InlineItemKind.LineBreak:
                 {

--- a/Lite/Layout/FlexEngine.cs
+++ b/Lite/Layout/FlexEngine.cs
@@ -48,8 +48,8 @@ internal static class FlexEngine
             if (pos == PositionType.Absolute || pos == PositionType.Fixed)
             {
                 // Static position = flex-start of main axis, cross-start
-                c.FlexStaticX = isRow ? (isReverse ? contentX + contentW : contentX) : contentX;
-                c.FlexStaticY = isRow ? contentY : (isReverse ? contentY + mainSize : contentY);
+                c.StaticX = isRow ? (isReverse ? contentX + contentW : contentX) : contentX;
+                c.StaticY = isRow ? contentY : (isReverse ? contentY + mainSize : contentY);
             }
         }
 

--- a/Lite/Layout/IntrinsicSizer.cs
+++ b/Lite/Layout/IntrinsicSizer.cs
@@ -68,6 +68,15 @@ internal static class IntrinsicSizer
         if (node.Children.Count == 0 && !string.IsNullOrEmpty(node.DisplayText))
             return TextMinMax(node);
 
+        // A table is sized by its COLUMNS, not by a line of inline content. Its rows and row
+        // groups are neither block-level nor inline, so the generic walk below collected them
+        // into an empty inline run and returned zero — which then shrink-to-fit a table inside a
+        // float or an abs-pos box down to nothing.
+        var nodeDisplay = node.GetDisplay();
+        if (nodeDisplay is DisplayType.Table or DisplayType.InlineTable
+            or DisplayType.TableRowGroup or DisplayType.TableRow)
+            return TableMinMax(node, viewportHeight);
+
         // Container: block children stack (widest wins); consecutive inline children flow into a run
         // (min = widest atomic unit, max = widest line). Mirrors BoxEngine.LayoutChildrenImpl grouping.
         float min = 0f, max = 0f;
@@ -112,6 +121,30 @@ internal static class IntrinsicSizer
                 min = Math.Max(min, rMin);
                 max = Math.Max(max, rMax);
             }
+        }
+        return (min, max);
+    }
+
+    /// <summary>
+    /// Intrinsic widths of a table box. Cells in a row sit side by side, so a row sums its cells;
+    /// a table (or row group) is as wide as its widest row. This is the column model auto table
+    /// layout uses, reduced to the two intrinsic sizes.
+    /// </summary>
+    private static (float Min, float Max) TableMinMax(LayoutNode node, float viewportHeight)
+    {
+        var display = node.GetDisplay();
+        var sumsChildren = display == DisplayType.TableRow;
+        float min = 0f, max = 0f;
+
+        foreach (var child in node.Children)
+        {
+            if (child.GetDisplay() == DisplayType.None) continue;
+            // Whitespace between rows/cells is not content (§17.2.1 discards it).
+            if (child.TagName == "#text" && string.IsNullOrWhiteSpace(child.DisplayText)) continue;
+
+            var (cMin, cMax) = OuterMinMax(child, viewportHeight);
+            if (sumsChildren) { min += cMin; max += cMax; }
+            else { min = Math.Max(min, cMin); max = Math.Max(max, cMax); }
         }
         return (min, max);
     }

--- a/Lite/Layout/TextMeasure.cs
+++ b/Lite/Layout/TextMeasure.cs
@@ -86,14 +86,41 @@ internal static class TextMeasure
         => widths is null or { Count: 0 } ? fallback : widths[Math.Min(index, widths.Count - 1)];
 
     /// <summary>
+    /// Measures text with 'letter-spacing' and 'word-spacing' applied — the width the painter
+    /// will actually draw. Spacing goes after each character (and after each space for
+    /// word-spacing); the trailing letter-space is dropped, as it is when painting.
+    /// </summary>
+    public static float MeasureWithSpacing(string text, SKFont font, float letterSpacing, float wordSpacing)
+    {
+        if (string.IsNullOrEmpty(text)) return 0f;
+        if (letterSpacing == 0f && wordSpacing == 0f) return font.MeasureText(text);
+
+        float w = 0f;
+        foreach (var ch in text)
+        {
+            w += font.MeasureText(ch.ToString()) + letterSpacing;
+            if (ch == ' ') w += wordSpacing;
+        }
+        return Math.Max(0f, w - letterSpacing);
+    }
+
+    /// <summary>The spacing a node's text is laid out with, so measurement and painting agree.</summary>
+    public static (float Letter, float Word) SpacingOf(LayoutNode node)
+    {
+        var fs = node.GetFontSize();
+        return (node.GetLetterSpacing(fs), node.GetWordSpacing(fs));
+    }
+
+    /// <summary>
     /// Measures text without wrapping — returns total width and single-line height.
     /// </summary>
-    public static (float Width, float Height, float Ascent) MeasureSingleLine(string text, SKFont font, float lineHeight = -1f)
+    public static (float Width, float Height, float Ascent) MeasureSingleLine(string text, SKFont font, float lineHeight = -1f,
+        float letterSpacing = 0f, float wordSpacing = 0f)
     {
         // Negative means "caller did not say"; a line-height of exactly 0 is a real value
         // ('line-height: 0' collapses the line box) and must not be replaced.
         if (lineHeight < 0f) lineHeight = font.Size * 1.4f;
-        return (font.MeasureText(text), lineHeight, ComputeAscent(font, lineHeight));
+        return (MeasureWithSpacing(text, font, letterSpacing, wordSpacing), lineHeight, ComputeAscent(font, lineHeight));
     }
 
     /// <summary>

--- a/Lite/Layout/TextMeasure.cs
+++ b/Lite/Layout/TextMeasure.cs
@@ -62,10 +62,12 @@ internal static class TextMeasure
     /// Wraps text into lines that fit within maxWidth, respecting the node's white-space mode.
     /// Each TextLine carries the text, measured width, line height, and baseline ascent.
     /// </summary>
-    public static List<TextLine> WrapText(string text, float maxWidth, SKFont font, WhiteSpace whiteSpace = WhiteSpace.Normal, float lineHeight = 0f,
+    public static List<TextLine> WrapText(string text, float maxWidth, SKFont font, WhiteSpace whiteSpace = WhiteSpace.Normal, float lineHeight = -1f,
         IReadOnlyList<float>? lineWidths = null)
     {
-        if (lineHeight <= 0f) lineHeight = font.Size * 1.4f;
+        // Negative means "caller did not say"; a line-height of exactly 0 is a real value
+        // ('line-height: 0' collapses the line box) and must not be replaced.
+        if (lineHeight < 0f) lineHeight = font.Size * 1.4f;
         return whiteSpace switch
         {
             WhiteSpace.Pre => SplitPreserved(text, font, wrap: false, lineHeight: lineHeight),
@@ -86,9 +88,11 @@ internal static class TextMeasure
     /// <summary>
     /// Measures text without wrapping — returns total width and single-line height.
     /// </summary>
-    public static (float Width, float Height, float Ascent) MeasureSingleLine(string text, SKFont font, float lineHeight = 0f)
+    public static (float Width, float Height, float Ascent) MeasureSingleLine(string text, SKFont font, float lineHeight = -1f)
     {
-        if (lineHeight <= 0f) lineHeight = font.Size * 1.4f;
+        // Negative means "caller did not say"; a line-height of exactly 0 is a real value
+        // ('line-height: 0' collapses the line box) and must not be replaced.
+        if (lineHeight < 0f) lineHeight = font.Size * 1.4f;
         return (font.MeasureText(text), lineHeight, ComputeAscent(font, lineHeight));
     }
 
@@ -186,10 +190,12 @@ internal static class TextMeasure
     }
 
     /// <summary>Preserve whitespace and newlines; optionally wrap long lines (pre / pre-wrap).</summary>
-    private static List<TextLine> SplitPreserved(string text, SKFont font, bool wrap, float maxWidth = float.MaxValue, float lineHeight = 0f)
+    private static List<TextLine> SplitPreserved(string text, SKFont font, bool wrap, float maxWidth = float.MaxValue, float lineHeight = -1f)
     {
         var lines = new List<TextLine>();
-        if (lineHeight <= 0f) lineHeight = font.Size * 1.4f;
+        // Negative means "caller did not say"; a line-height of exactly 0 is a real value
+        // ('line-height: 0' collapses the line box) and must not be replaced.
+        if (lineHeight < 0f) lineHeight = font.Size * 1.4f;
         var ascent = ComputeAscent(font, lineHeight);
 
         var rawLines = text.Split('\n');

--- a/Lite/Layout/TextMeasure.cs
+++ b/Lite/Layout/TextMeasure.cs
@@ -62,7 +62,8 @@ internal static class TextMeasure
     /// Wraps text into lines that fit within maxWidth, respecting the node's white-space mode.
     /// Each TextLine carries the text, measured width, line height, and baseline ascent.
     /// </summary>
-    public static List<TextLine> WrapText(string text, float maxWidth, SKFont font, WhiteSpace whiteSpace = WhiteSpace.Normal, float lineHeight = 0f)
+    public static List<TextLine> WrapText(string text, float maxWidth, SKFont font, WhiteSpace whiteSpace = WhiteSpace.Normal, float lineHeight = 0f,
+        IReadOnlyList<float>? lineWidths = null)
     {
         if (lineHeight <= 0f) lineHeight = font.Size * 1.4f;
         return whiteSpace switch
@@ -71,9 +72,16 @@ internal static class TextMeasure
             WhiteSpace.PreWrap => SplitPreserved(text, font, wrap: true, maxWidth, lineHeight),
             WhiteSpace.PreLine => SplitPreLine(text, maxWidth, font, lineHeight),
             WhiteSpace.NoWrap => WrapCollapsed(text, float.MaxValue, font, lineHeight),
-            _ => WrapCollapsed(text, maxWidth, font, lineHeight),
+            _ => WrapCollapsed(text, maxWidth, font, lineHeight, lineWidths),
         };
     }
+
+    /// <summary>The width available to line <paramref name="index"/>: <paramref name="widths"/>
+    /// when the caller supplied a per-line band (text beside a float, CSS 2.1 §9.5), otherwise the
+    /// single <paramref name="fallback"/>. Past the end of the list the last band repeats — below
+    /// the lowest float the band no longer changes.</summary>
+    internal static float LineWidthAt(IReadOnlyList<float>? widths, int index, float fallback)
+        => widths is null or { Count: 0 } ? fallback : widths[Math.Min(index, widths.Count - 1)];
 
     /// <summary>
     /// Measures text without wrapping — returns total width and single-line height.
@@ -129,14 +137,15 @@ internal static class TextMeasure
     // -------------------------------------------------------------------------
 
     /// <summary>Collapse whitespace and word-wrap at maxWidth (normal / nowrap).</summary>
-    private static List<TextLine> WrapCollapsed(string text, float maxWidth, SKFont font, float lineHeight)
+    private static List<TextLine> WrapCollapsed(string text, float maxWidth, SKFont font, float lineHeight,
+        IReadOnlyList<float>? lineWidths = null)
     {
         var lines = new List<TextLine>();
         var ascent = ComputeAscent(font, lineHeight);
 
         // Fast path: text already fits — return it verbatim so that leading/trailing
         // spaces (significant in inline runs like " and ") are preserved.
-        if (font.MeasureText(text) <= maxWidth)
+        if (font.MeasureText(text) <= LineWidthAt(lineWidths, 0, maxWidth))
         {
             lines.Add(new TextLine(text, font.MeasureText(text), lineHeight, ascent));
             return lines;
@@ -144,14 +153,19 @@ internal static class TextMeasure
 
         var words = text.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
         var sb = new System.Text.StringBuilder();
+        // Each line is measured against ITS OWN width: beside a float the available width changes
+        // from line to line, so a single maxWidth would wrap the whole paragraph to the narrow
+        // band even below the float's bottom edge.
+        var limit = LineWidthAt(lineWidths, 0, maxWidth);
 
         foreach (var word in words)
         {
             var candidate = sb.Length == 0 ? word : sb + " " + word;
-            if (font.MeasureText(candidate) > maxWidth && sb.Length > 0)
+            if (font.MeasureText(candidate) > limit && sb.Length > 0)
             {
                 var lineText = sb.ToString();
                 lines.Add(new TextLine(lineText, font.MeasureText(lineText), lineHeight, ascent));
+                limit = LineWidthAt(lineWidths, lines.Count, maxWidth);
                 sb.Clear();
                 sb.Append(word);
             }

--- a/Lite/Lite.csproj
+++ b/Lite/Lite.csproj
@@ -30,6 +30,10 @@
     <PackageReference Include="AngleSharp.Css" Version="0.17.0" />
     <PackageReference Include="Jint" Version="4.9.3" />
     <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <!-- Legacy single- and multi-byte charsets (Shift_JIS, windows-125x, koi8-r, iso-8859-x).
+         .NET Core dropped them from the shared framework; a stylesheet or document that
+         declares one is otherwise decoded as UTF-8 and comes out as mojibake. -->
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Lite/Models/LayoutNode.cs
+++ b/Lite/Models/LayoutNode.cs
@@ -233,6 +233,14 @@ public class LayoutNode
     ];
 
     /// <summary>
+    /// The line-box fragments this inline node was broken into, when it produced more than one:
+    /// each carries the rect it occupies and the slice of text drawn there. An inline box that
+    /// spans several lines has one box per line, so its background and borders paint on each —
+    /// with a single Box only the last fragment was painted.
+    /// </summary>
+    public List<(SKRect Rect, string Text)>? InlineFragments { get; set; }
+
+    /// <summary>
     /// Per-line-box band for this text node when floats make the available width vary down the
     /// paragraph (CSS 2.1 §9.5): the absolute left edge and width of each successive line. Layout
     /// wraps against these, and the painter draws each line at its own X, so both agree. Null when

--- a/Lite/Models/LayoutNode.cs
+++ b/Lite/Models/LayoutNode.cs
@@ -207,6 +207,14 @@ public class LayoutNode
     public string DisplayText => TextOverride ?? Text;
     public List<EventListenerEntry> EventListeners { get; } = [];
     /// <summary>
+    /// Per-line-box band for this text node when floats make the available width vary down the
+    /// paragraph (CSS 2.1 §9.5): the absolute left edge and width of each successive line. Layout
+    /// wraps against these, and the painter draws each line at its own X, so both agree. Null when
+    /// no float shortens the text.
+    /// </summary>
+    public List<(float X, float Width)>? LineBands { get; set; }
+
+    /// <summary>
     /// The element's 'font-size' as a computed length in px (CSS 2.1 §15.7), resolved once by the
     /// Parser against the parent's computed size. Descendants inherit this number, so a relative
     /// unit is never applied twice. Null on nodes the Parser did not build (JS-created elements),

--- a/Lite/Models/LayoutNode.cs
+++ b/Lite/Models/LayoutNode.cs
@@ -207,6 +207,30 @@ public class LayoutNode
     public string DisplayText => TextOverride ?? Text;
     public List<EventListenerEntry> EventListeners { get; } = [];
     /// <summary>
+    /// Neutralises the NON-INHERITED properties a synthesized box (an anonymous table box, a
+    /// generated-content box, a #text child split off an element) would otherwise pick up from
+    /// the style object it borrows from its originating element. Such a box shares that object,
+    /// so a parent's 'position: absolute' or 'float' would read back as its own and take it out
+    /// of flow — an anonymous table inside an abs-pos box was skipped by its own parent's layout
+    /// for exactly that reason. Inherited properties (colour, font, text-align, …) are left alone:
+    /// a synthesized box is supposed to inherit those.
+    /// </summary>
+    public void ResetNonInheritedStyles()
+    {
+        foreach (var prop in NonInheritedResets)
+            StyleOverrides[prop.Key] = prop.Value;
+    }
+
+    private static readonly (string Key, string Value)[] NonInheritedResets =
+    [
+        ("position", "static"), ("top", "auto"), ("right", "auto"), ("bottom", "auto"), ("left", "auto"),
+        ("float", "none"), ("clear", "none"), ("z-index", "auto"), ("overflow", "visible"),
+        ("width", "auto"), ("height", "auto"),
+        ("min-width", "0"), ("min-height", "0"), ("max-width", "none"), ("max-height", "none"),
+        ("background-color", "transparent"), ("background-image", "none"),
+    ];
+
+    /// <summary>
     /// Per-line-box band for this text node when floats make the available width vary down the
     /// paragraph (CSS 2.1 §9.5): the absolute left edge and width of each successive line. Layout
     /// wraps against these, and the painter draws each line at its own X, so both agree. Null when

--- a/Lite/Models/LayoutNode.cs
+++ b/Lite/Models/LayoutNode.cs
@@ -214,6 +214,9 @@ public class LayoutNode
     /// of flow — an anonymous table inside an abs-pos box was skipped by its own parent's layout
     /// for exactly that reason. Inherited properties (colour, font, text-align, …) are left alone:
     /// a synthesized box is supposed to inherit those.
+    /// <para>Only the properties that decide where a box goes and how big it is are reset.
+    /// 'background' deliberately is not: an inline box's background is painted by the #text child
+    /// that carries its content, so clearing it there would lose the background entirely.</para>
     /// </summary>
     public void ResetNonInheritedStyles()
     {
@@ -227,7 +230,6 @@ public class LayoutNode
         ("float", "none"), ("clear", "none"), ("z-index", "auto"), ("overflow", "visible"),
         ("width", "auto"), ("height", "auto"),
         ("min-width", "0"), ("min-height", "0"), ("max-width", "none"), ("max-height", "none"),
-        ("background-color", "transparent"), ("background-image", "none"),
     ];
 
     /// <summary>

--- a/Lite/Models/LayoutNode.cs
+++ b/Lite/Models/LayoutNode.cs
@@ -207,6 +207,14 @@ public class LayoutNode
     public string DisplayText => TextOverride ?? Text;
     public List<EventListenerEntry> EventListeners { get; } = [];
     /// <summary>
+    /// The element's 'font-size' as a computed length in px (CSS 2.1 §15.7), resolved once by the
+    /// Parser against the parent's computed size. Descendants inherit this number, so a relative
+    /// unit is never applied twice. Null on nodes the Parser did not build (JS-created elements),
+    /// which fall back to resolving the style value.
+    /// </summary>
+    public float? ComputedFontSize { get; set; }
+
+    /// <summary>
     /// CSS 2.1 §10.3.7 / §10.6.4 static position: the left/top MARGIN edge of the hypothetical
     /// box this element would have generated if its 'position' were 'static', in absolute layout
     /// coordinates. Recorded by the normal-flow pass (BoxEngine) and by FlexEngine as each

--- a/Lite/Models/LayoutNode.cs
+++ b/Lite/Models/LayoutNode.cs
@@ -207,11 +207,14 @@ public class LayoutNode
     public string DisplayText => TextOverride ?? Text;
     public List<EventListenerEntry> EventListeners { get; } = [];
     /// <summary>
-    /// Static position within a flex container, set by FlexEngine for abs-pos children.
-    /// Used by BoxEngine.ResolveAbsoluteBox when top/left are auto.
+    /// CSS 2.1 §10.3.7 / §10.6.4 static position: the left/top MARGIN edge of the hypothetical
+    /// box this element would have generated if its 'position' were 'static', in absolute layout
+    /// coordinates. Recorded by the normal-flow pass (BoxEngine) and by FlexEngine as each
+    /// out-of-flow child is passed over, and used by BoxEngine.ResolveAbsoluteBox when the
+    /// corresponding offsets are 'auto'.
     /// </summary>
-    public float? FlexStaticX { get; set; }
-    public float? FlexStaticY { get; set; }
+    public float? StaticX { get; set; }
+    public float? StaticY { get; set; }
 
     public LayoutNode(string? id, string tagName, string text, ICssStyleDeclaration style, string? href = null)
     {

--- a/Lite/Network/ResourceLoader.cs
+++ b/Lite/Network/ResourceLoader.cs
@@ -80,11 +80,5 @@ internal static class ResourceLoader
         return SKBitmap.Decode(bytes);
     }
 
-    private static string? ResolveUrl(string src, string? baseUrl)
-    {
-        if (Uri.TryCreate(src, UriKind.Absolute, out _)) return src;
-        if (baseUrl != null && Uri.TryCreate(new Uri(baseUrl), src, out var resolved))
-            return resolved.ToString();
-        return null;
-    }
+    private static string? ResolveUrl(string src, string? baseUrl) => UrlUtils.Resolve(src, baseUrl);
 }

--- a/Lite/Network/UrlUtils.cs
+++ b/Lite/Network/UrlUtils.cs
@@ -1,0 +1,42 @@
+namespace Lite.Network;
+
+/// <summary>URL helpers shared by every place that resolves a document-relative reference.</summary>
+internal static class UrlUtils
+{
+    /// <summary>
+    /// True when <paramref name="url"/> starts with a scheme (RFC 3986 §3.1), i.e. it is an
+    /// absolute URL that must NOT be resolved against a base.
+    /// <para><see cref="Uri.TryCreate(string, UriKind, out Uri)"/> with
+    /// <see cref="UriKind.Absolute"/> cannot answer this: on Unix it accepts any path-absolute
+    /// reference ("/fonts/ahem.css") as an implicit <c>file:</c> URI, so a root-relative
+    /// stylesheet, image or form action was handed to the HTTP client verbatim instead of being
+    /// resolved against the document base — it then failed with "invalid request URI".</para>
+    /// </summary>
+    public static bool IsAbsolute(string? url)
+    {
+        if (string.IsNullOrEmpty(url)) return false;
+        var colon = url.IndexOf(':');
+        if (colon <= 0) return false;
+        if (!char.IsAsciiLetter(url[0])) return false;
+        for (int i = 1; i < colon; i++)
+        {
+            var c = url[i];
+            if (!char.IsAsciiLetterOrDigit(c) && c != '+' && c != '-' && c != '.') return false;
+        }
+        return Uri.TryCreate(url, UriKind.Absolute, out _);
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="url"/> against <paramref name="baseUrl"/>, returning null when it
+    /// is relative and there is no usable base.
+    /// </summary>
+    public static string? Resolve(string? url, string? baseUrl)
+    {
+        if (string.IsNullOrEmpty(url)) return null;
+        if (IsAbsolute(url)) return url;
+        if (!string.IsNullOrEmpty(baseUrl) && Uri.TryCreate(baseUrl, UriKind.Absolute, out var b) &&
+            Uri.TryCreate(b, url, out var resolved))
+            return resolved.ToString();
+        return null;
+    }
+}

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -1580,9 +1580,24 @@ internal static class Parser
         else if (!string.IsNullOrWhiteSpace(scriptEl.TextContent))
         {
             // Inline scripts always run in document position (defer/async do not apply).
-            if (isModule) _pendingModules.Add((NextInlineModuleSpecifier(), scriptEl.TextContent));
-            else _pendingScripts.Add(scriptEl.TextContent);
+            var inlineCode = StripCdata(scriptEl.TextContent);
+            if (isModule) _pendingModules.Add((NextInlineModuleSpecifier(), inlineCode));
+            else _pendingScripts.Add(inlineCode);
         }
+    }
+
+    /// <summary>
+    /// Unwraps the <c>&lt;![CDATA[ … ]]&gt;</c> section XHTML documents wrap inline scripts in, so
+    /// the markup stays well-formed XML. The characters are not JavaScript: left in place the whole
+    /// script fails to parse on its first token, and any function it defines never exists. Most of
+    /// the CSS 2.1 suite's scripted tests are XHTML and written this way.
+    /// </summary>
+    private static string StripCdata(string code)
+    {
+        var trimmed = code.Trim();
+        if (!trimmed.StartsWith("<![CDATA[", StringComparison.Ordinal)) return code;
+        var end = trimmed.LastIndexOf("]]>", StringComparison.Ordinal);
+        return end < 9 ? trimmed[9..] : trimmed[9..end];
     }
 
     /// <summary>Routes an external classic script's code into the in-position, deferred, or async

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -464,14 +464,8 @@ internal static class Parser
         }
     }
 
-    private static string? ResolveUrl(string src)
-    {
-        if (Uri.TryCreate(src, UriKind.Absolute, out _)) return src;
-        var baseUrl = _documentBaseUrl ?? _baseUrl;
-        if (baseUrl != null && Uri.TryCreate(new Uri(baseUrl), src, out var resolved))
-            return resolved.ToString();
-        return null;
-    }
+    private static string? ResolveUrl(string src) =>
+        Lite.Network.UrlUtils.Resolve(src, _documentBaseUrl ?? _baseUrl);
 
     /// <summary>
     /// Recursively inlines <c>@import</c> rules (CSS 2.1 §6.3): fetches each imported sheet
@@ -493,10 +487,8 @@ internal static class Parser
         {
             var importUrl = m.Groups[1].Value.Trim();
             var media = m.Groups[2].Value.Trim();
-            string resolved;
-            if (Uri.TryCreate(importUrl, UriKind.Absolute, out var abs)) resolved = abs.ToString();
-            else if (Uri.TryCreate(new Uri(baseUrl), importUrl, out var rel)) resolved = rel.ToString();
-            else return "";
+            var resolved = Lite.Network.UrlUtils.Resolve(importUrl, baseUrl);
+            if (resolved is null) return "";
             try
             {
                 var imported = _httpClient.GetStringAsync(resolved).Result;
@@ -981,6 +973,9 @@ internal static class Parser
 
         // Create ::before and ::after pseudo-element children (using the snapshot taken above)
         CreatePseudoElementChildren(node, directTextRaw);
+        // ::first-letter runs after them: the spec includes ::before content in the first letter,
+        // and the split needs the final child list.
+        CreateFirstLetterChild(node);
 
         return node;
     }
@@ -1094,6 +1089,88 @@ internal static class Parser
             pseudoNode.Parent = node;
             node.Children.Add(pseudoNode);
         }
+    }
+
+    /// <summary>
+    /// CSS 2.1 §5.12.1: splits off the first letter of a block's first line into a real inline
+    /// box carrying the <c>::first-letter</c> declarations, so it takes part in layout — it
+    /// contributes its own font metrics and 'line-height' to the line box, its width to line
+    /// breaking, and it paints backgrounds, borders and every other property through the ordinary
+    /// inline path. Styling it at paint time instead (re-drawing the first characters in another
+    /// font) left the line box sized for the parent's font, so a larger first letter overlapped
+    /// the line above and the whole block sat at the wrong height.
+    /// <para>The "first letter" is the first letter plus any Ps/Pe/Pi/Pf/Po punctuation that
+    /// precedes or follows it. Text that is only punctuation yields no first-letter box.</para>
+    /// </summary>
+    private static void CreateFirstLetterChild(LayoutNode node)
+    {
+        if (node.FirstLetterStyles is not { Count: > 0 } styles) return;
+        // Only a block container gets a ::first-letter; an inline one inherits its block's.
+        if (node.StyleOverrides.TryGetValue("display", out var d) && d is "none" or "inline") return;
+
+        // The first letter comes from the first in-flow text in the block: the node's own text, or
+        // the first descendant that has some (a leading ::before box, or an inline child).
+        var host = FindFirstTextHost(node);
+        if (host is null) return;
+
+        var text = host.DisplayText;
+        var len = FirstLetterLength(text);
+        if (len <= 0) return;
+
+        var letter = new LayoutNode(null, "#pseudo-first-letter", text[..len], host.Style);
+        letter.StyleOverrides["display"] = "inline";
+        foreach (var (p, v) in styles)
+            if (p != "content" && p != "display") letter.StyleOverrides[p] = v;
+
+        var rest = new LayoutNode(null, "#text", text[len..], host.Style);
+        rest.StyleOverrides["display"] = "inline";
+
+        // The host keeps its box (and its own styles) but hands its text to the two new children,
+        // which flow inside it as ordinary inline content.
+        host.TextOverride = "";
+        letter.Parent = host;
+        rest.Parent = host;
+        host.Children.Insert(0, rest);
+        host.Children.Insert(0, letter);
+    }
+
+    /// <summary>The nearest node in document order whose own text would start
+    /// <paramref name="node"/>'s first line: the node itself, or its first inline descendant with
+    /// text. Stops at anything that is not inline-level — a block child starts its own first line
+    /// and gets its own ::first-letter.</summary>
+    private static LayoutNode? FindFirstTextHost(LayoutNode node)
+    {
+        if (!string.IsNullOrEmpty(node.DisplayText)) return node;
+        foreach (var child in node.Children)
+        {
+            if (child.StyleOverrides.TryGetValue("display", out var cd) && cd is not ("inline" or "inline-block"))
+                return null;
+            if (!string.IsNullOrWhiteSpace(child.DisplayText)) return child;
+            if (child.Children.Count > 0 && FindFirstTextHost(child) is { } inner) return inner;
+        }
+        return null;
+    }
+
+    /// <summary>Length of the ::first-letter run at the start of <paramref name="text"/>: any
+    /// leading Ps/Pe/Pi/Pf/Po punctuation, the letter itself, and any punctuation directly after
+    /// it (CSS 2.1 §5.12.1). Zero when there is no letter at all.</summary>
+    internal static int FirstLetterLength(string text)
+    {
+        static bool IsFirstLetterPunctuation(char c) =>
+            System.Globalization.CharUnicodeInfo.GetUnicodeCategory(c) is
+                System.Globalization.UnicodeCategory.OpenPunctuation or
+                System.Globalization.UnicodeCategory.ClosePunctuation or
+                System.Globalization.UnicodeCategory.InitialQuotePunctuation or
+                System.Globalization.UnicodeCategory.FinalQuotePunctuation or
+                System.Globalization.UnicodeCategory.OtherPunctuation;
+
+        var i = 0;
+        while (i < text.Length && char.IsWhiteSpace(text[i])) i++;
+        while (i < text.Length && IsFirstLetterPunctuation(text[i])) i++;
+        if (i >= text.Length) return 0;   // punctuation only: no first letter to style
+        i++;                              // the letter itself
+        while (i < text.Length && IsFirstLetterPunctuation(text[i])) i++;
+        return i;
     }
 
     /// <summary>

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -232,10 +232,11 @@ internal static class Parser
         // itself. They are re-applied per element inside Traverse.
         NeutralizePseudoElementRules(document);
 
-        var root = Traverse(document.DocumentElement, 0);
-
-        // Collect all CSS rules for dynamic class-based style re-evaluation
+        // Collect all CSS rules for dynamic class-based style re-evaluation — and, before the
+        // traversal, so it can ask which elements declare their own 'font-size'.
         CollectCssRules(document);
+
+        var root = Traverse(document.DocumentElement, 0, DefaultFontSizePx);
 
         // Always create the JS engine so inline onclick/on* handlers work,
         // even when there are no external or inline script blocks.
@@ -566,7 +567,7 @@ internal static class Parser
         return src[start..end].Trim();
     }
 
-    private static LayoutNode Traverse(IElement element, int indent)
+    private static LayoutNode Traverse(IElement element, int indent, float parentFontPx = 16f)
     {
         // Normalize tag name to uppercase — AngleSharp returns lowercase for SVG namespace elements
         var tag = element.TagName.ToUpperInvariant();
@@ -607,6 +608,14 @@ internal static class Parser
 
         var href = tag == "A" ? element.GetAttribute("href") : null;
         var node = new LayoutNode(element.Id, tag, directText, elementStyle, href);
+
+        // CSS 2.1 §15.7: font-size COMPUTES to a length, and that length is what descendants
+        // inherit. AngleSharp hands every descendant the specified value instead ("2em"), which
+        // layout then re-resolved against the parent's already-scaled size, so a single
+        // `font-size: 2em` doubled again at every level below it. Resolve it once here, against
+        // the parent's computed size, and hand the result down.
+        var fontPx = ResolveOwnFontSize(element, parentFontPx);
+        node.ComputedFontSize = fontPx;
 
         // Extract flex-related CSS properties that AngleSharp doesn't cascade
         ExtractMatchedCssProperties(element, node);
@@ -948,7 +957,7 @@ internal static class Parser
                         continue;
                     }
                     if (SkipTags.Contains(childTag)) { CollectScriptsRecursive(childEl); continue; }
-                    node.AddChild(Traverse(childEl, indent + 1));
+                    node.AddChild(Traverse(childEl, indent + 1, fontPx));
                 }
             }
         }
@@ -959,7 +968,7 @@ internal static class Parser
                 var childTag = child.TagName.ToUpperInvariant();
                 if (childTag == "SCRIPT") { CollectScript(child); continue; }
                 if (SkipTags.Contains(childTag)) { CollectScriptsRecursive(child); continue; }
-                node.AddChild(Traverse(child, indent + 1));
+                node.AddChild(Traverse(child, indent + 1, fontPx));
             }
         }
 
@@ -1089,6 +1098,101 @@ internal static class Parser
             pseudoNode.Parent = node;
             node.Children.Add(pseudoNode);
         }
+    }
+
+    /// <summary>The initial font size — the value the root element inherits.</summary>
+    internal const float DefaultFontSizePx = 16f;
+
+    /// <summary>
+    /// The used font size of <paramref name="element"/> in px: its OWN cascaded 'font-size'
+    /// declaration resolved against <paramref name="parentPx"/>, or the inherited
+    /// <paramref name="parentPx"/> when it declares none. Only a declaration on the element
+    /// itself may re-scale a relative unit — an inherited 'font-size' is already a computed
+    /// length and must not be applied a second time.
+    /// </summary>
+    private static float ResolveOwnFontSize(IElement element, float parentPx)
+    {
+        var declared = OwnFontSizeDeclaration(element);
+        return declared is null ? parentPx : ResolveFontSizeValue(declared, parentPx);
+    }
+
+    /// <summary>The winning 'font-size' declaration for the element itself (inline style, then
+    /// author/UA rules ordered by !important, specificity and source order), or null when none
+    /// of them names the property.</summary>
+    private static string? OwnFontSizeDeclaration(IElement element)
+    {
+        string? best = null;
+        var bestKey = (Important: false, Specificity: -1, Order: -1);
+
+        foreach (var rule in CssRules)
+        {
+            if (FontSizeOf(rule.Properties) is not { } val) continue;
+            try { if (!element.Matches(rule.Selector)) continue; }
+            catch { continue; }
+            var key = (rule.ImportantProps.Contains("font-size") || rule.ImportantProps.Contains("font"),
+                       rule.Specificity, rule.Order);
+            if (best is null || key.CompareTo(bestKey) > 0) { best = val; bestKey = key; }
+        }
+
+        // An inline declaration outranks every non-important rule (CSS 2.1 §6.4.3).
+        if (element.GetAttribute("style") is { Length: > 0 } inline && !bestKey.Important)
+        {
+            var (props, _) = ParseDeclarations(inline);
+            if (FontSizeOf(props) is { } iv) return iv;
+        }
+        return best;
+    }
+
+    /// <summary>The font-size a declaration block sets, either directly or through the 'font'
+    /// shorthand (§15.8) — <c>font: 1in Ahem</c> is how most of the CSS 2.1 suite sizes text, and
+    /// missing it would leave those elements at the inherited size.</summary>
+    private static string? FontSizeOf(Dictionary<string, string> props)
+    {
+        if (props.TryGetValue("font-size", out var direct) && !string.IsNullOrWhiteSpace(direct))
+            return direct;
+        if (!props.TryGetValue("font", out var shorthand) || string.IsNullOrWhiteSpace(shorthand))
+            return null;
+        // <style> <variant> <weight> <size>[/<line-height>] <family>: the size is the last token
+        // before the family list, so scan for the first token that parses as a length/percentage.
+        foreach (var token in shorthand.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var t = token.Split('/')[0].Trim();
+            if (t.Length == 0 || t.EndsWith(",", StringComparison.Ordinal)) continue;
+            if (t.EndsWith("%", StringComparison.Ordinal)) return t;
+            if (char.IsAsciiDigit(t[0]) || t[0] == '.') return t;
+            if (t.ToLowerInvariant() is "xx-small" or "x-small" or "small" or "medium" or "large"
+                or "x-large" or "xx-large" or "larger" or "smaller") return t;
+        }
+        return null;
+    }
+
+    /// <summary>Resolves one 'font-size' value against the parent's computed size, including the
+    /// absolute/relative keywords (§15.7).</summary>
+    private static float ResolveFontSizeValue(string value, float parentPx)
+    {
+        value = value.Trim();
+        switch (value.ToLowerInvariant())
+        {
+            case "xx-small": return 9f;
+            case "x-small": return 10f;
+            case "small": return 13f;
+            case "medium": return 16f;
+            case "large": return 18f;
+            case "x-large": return 24f;
+            case "xx-large": return 32f;
+            case "larger": return parentPx * 1.2f;
+            case "smaller": return parentPx / 1.2f;
+            case "inherit": case "unset": return parentPx;
+            case "initial": return DefaultFontSizePx;
+        }
+        if (value.EndsWith("%", StringComparison.Ordinal) &&
+            float.TryParse(value[..^1], System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var pct))
+            return parentPx * pct / 100f;
+        // em/ex resolve against the PARENT size for this property alone; rem against the root.
+        // A used size of 0 is legitimate ('font-size: 0' hides text) — only an unparseable value
+        // falls back to the inherited size, and a negative one is invalid, so it clamps to 0.
+        return CssUnits.TryParse(value, parentPx, parentPx, 0, 0, out var px) ? Math.Max(0f, px) : parentPx;
     }
 
     /// <summary>

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -991,6 +991,13 @@ internal static class Parser
             }
         }
 
+        // <table cellspacing> / <table cellpadding>: HTML presentational hints for 'border-spacing'
+        // on the table and 'padding' on every cell in it. Ignoring them left the UA defaults
+        // (2px spacing, 1px cell padding) in place, so a `cellpadding="0" cellspacing="0"` table
+        // sat 3px lower and wider than the CSS-equivalent it is meant to match.
+        if (tag == "TABLE")
+            ApplyTableSpacingAttributes(element, node);
+
         // <picture>: now that the <img> and <source> children exist, pick the source the <img>
         // should display (media/type-based selection; falls back to the <img>'s own src).
         if (tag == "PICTURE")
@@ -1311,6 +1318,50 @@ internal static class Parser
         }
         if (start < value.Length) tokens.Add(value[start..]);
         return tokens;
+    }
+
+    /// <summary>
+    /// Applies the <c>cellspacing</c> and <c>cellpadding</c> content attributes (HTML 4 §11.2.1):
+    /// the first is 'border-spacing' on the table, the second 'padding' on each of its cells.
+    /// Presentational hints lose to an author declaration, so a cell that sets its own padding
+    /// keeps it. Called after the subtree is built, since it has to reach the cells.
+    /// </summary>
+    private static void ApplyTableSpacingAttributes(IElement element, LayoutNode node)
+    {
+        if (element.GetAttribute("cellspacing")?.Trim() is { Length: > 0 } spacing &&
+            float.TryParse(spacing.TrimEnd('%'), System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var sp))
+        {
+            // An author declaration for 'border-spacing' is already in StyleOverrides (it is one of
+            // the properties the engine cascades itself), so its absence there means the attribute
+            // is free to apply. AngleSharp's computed value always reports something, so asking it
+            // would suppress the hint every time.
+            if (!node.StyleOverrides.ContainsKey("border-spacing"))
+                node.StyleOverrides["border-spacing"] = $"{sp.ToString(System.Globalization.CultureInfo.InvariantCulture)}px";
+        }
+
+        if (element.GetAttribute("cellpadding")?.Trim() is not { Length: > 0 } padding ||
+            !float.TryParse(padding.TrimEnd('%'), System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var pad))
+            return;
+
+        var value = $"{pad.ToString(System.Globalization.CultureInfo.InvariantCulture)}px";
+        void ApplyToCells(LayoutNode n)
+        {
+            foreach (var child in n.Children)
+            {
+                if (child.TagName is "TD" or "TH")
+                    foreach (var side in new[] { "top", "right", "bottom", "left" })
+                    {
+                        // A cell that declares its own padding keeps it.
+                        var own = child.Style.GetPropertyValueSafe($"padding-{side}")?.Trim();
+                        if (string.IsNullOrEmpty(own) || own == "1px") child.StyleOverrides[$"padding-{side}"] = value;
+                    }
+                // A nested table has its own cellpadding; do not reach into it.
+                if (child.TagName != "TABLE") ApplyToCells(child);
+            }
+        }
+        ApplyToCells(node);
     }
 
     /// <summary>The initial font size — the value the root element inherits.</summary>

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -8,6 +8,7 @@ using Lite.Layout;
 using Lite.Models;
 using Lite.Network;
 using Lite.Scripting;
+using System.Text;
 
 namespace Lite;
 
@@ -167,6 +168,7 @@ internal static class Parser
             {
                 string css;
                 string cssBase;
+                var sheetCharset = document.CharacterSet;
                 if (DataUri.IsDataUri(href))
                 {
                     if (!DataUri.TryDecodeText(href, out css, out _)) continue;
@@ -176,10 +178,13 @@ internal static class Parser
                 {
                     var cssUrl = ResolveUrl(href);
                     if (cssUrl is null) continue;
-                    css = _httpClient.GetStringAsync(cssUrl).Result;
+                    // §4.4 also consults the linking element's charset attribute and, failing
+                    // that, the referring document's own encoding.
+                    css = FetchCssText(cssUrl, link.GetAttribute("charset"), document.CharacterSet,
+                                       out sheetCharset);
                     cssBase = cssUrl;
                 }
-                css = InlineImports(css, cssBase);
+                css = InlineImports(css, cssBase, sheetCharset);
                 var styleEl = document.CreateElement("style");
                 styleEl.TextContent = css;
                 head.AppendChild(styleEl);
@@ -473,7 +478,7 @@ internal static class Parser
     /// (resolved against <paramref name="baseUrl"/>), inlines ITS imports, and substitutes the
     /// text. A media-qualified import (<c>@import url(x) print;</c>) is wrapped in an @media block.
     /// </summary>
-    private static string InlineImports(string css, string baseUrl, int depth = 0)
+    private static string InlineImports(string css, string baseUrl, string? referrerCharset = null, int depth = 0)
     {
         if (depth > 8 || string.IsNullOrEmpty(css) ||
             !css.Contains("@import", StringComparison.OrdinalIgnoreCase))
@@ -492,8 +497,8 @@ internal static class Parser
             if (resolved is null) return "";
             try
             {
-                var imported = _httpClient.GetStringAsync(resolved).Result;
-                imported = InlineImports(imported, resolved, depth + 1);
+                var imported = FetchCssText(resolved, null, referrerCharset, out var importedCharset);
+                imported = InlineImports(imported, resolved, importedCharset, depth + 1);
                 return string.IsNullOrEmpty(media) ? imported : $"@media {media} {{\n{imported}\n}}";
             }
             catch (Exception ex)
@@ -1099,6 +1104,89 @@ internal static class Parser
             node.Children.Add(pseudoNode);
         }
     }
+
+    /// <summary>
+    /// Fetches a stylesheet and decodes its bytes per CSS 2.1 §4.4, in the spec's priority order:
+    /// a byte-order mark, then an <c>@charset</c> rule at the very start of the sheet, then the
+    /// HTTP <c>Content-Type</c> charset, then UTF-8. Decoding everything as UTF-8 (what
+    /// GetStringAsync does without a charset) both mangles a sheet in another encoding and leaves
+    /// a U+FEFF at the front of one that carries a BOM — which silently breaks its first selector.
+    /// </summary>
+    private static string FetchCssText(string url, string? linkCharset, string? referrerCharset,
+        out string usedCharset)
+    {
+        using var response = _httpClient.GetAsync(url).Result;
+        response.EnsureSuccessStatusCode();
+        var bytes = response.Content.ReadAsByteArrayAsync().Result;
+        return DecodeCss(bytes, response.Content.Headers.ContentType?.CharSet,
+                         linkCharset, referrerCharset, out usedCharset);
+    }
+
+    /// <summary>Decodes stylesheet bytes; see <see cref="FetchCssText"/> for the priority order.
+    /// <paramref name="usedCharset"/> receives the encoding actually applied, which becomes the
+    /// referrer charset for any sheet this one imports. Exposed for tests.</summary>
+    internal static string DecodeCss(byte[] bytes, string? httpCharset, string? linkCharset,
+        string? referrerCharset, out string usedCharset)
+    {
+        usedCharset = "utf-8";
+        // 1. BOM — authoritative, and consumed rather than decoded into the text.
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+            return Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+        if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
+        {
+            usedCharset = "utf-16le";
+            return Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+        }
+        if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF)
+        {
+            usedCharset = "utf-16be";
+            return Encoding.BigEndianUnicode.GetString(bytes, 2, bytes.Length - 2);
+        }
+
+        // 2. @charset at the very start of the sheet. Its own name has to be readable as ASCII,
+        //    which it is in every encoding CSS 2.1 allows here.
+        var probe = Encoding.ASCII.GetString(bytes, 0, Math.Min(bytes.Length, 128));
+        if (probe.StartsWith("@charset \"", StringComparison.Ordinal))
+        {
+            var end = probe.IndexOf("\";", 10, StringComparison.Ordinal);
+            if (end > 10 && TryGetEncoding(probe[10..end]) is { } declared)
+            {
+                usedCharset = declared.WebName;
+                return declared.GetString(bytes);
+            }
+        }
+
+        // 3. HTTP, 4. the linking element's charset attribute, 5. the referring sheet/document's
+        //    encoding, 6. UTF-8.
+        foreach (var candidate in new[] { httpCharset, linkCharset, referrerCharset })
+            if (TryGetEncoding(candidate) is { } enc)
+            {
+                usedCharset = enc.WebName;
+                return enc.GetString(bytes);
+            }
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    /// <summary>Resolves a charset name to an encoding, or null when it is unknown. The legacy
+    /// code pages (Shift_JIS, windows-125x, koi8-r, iso-8859-x) are not in .NET's shared framework,
+    /// so the CodePages provider is registered once here to make them resolvable.</summary>
+    private static Encoding? TryGetEncoding(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return null;
+        if (!_codePagesRegistered)
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            _codePagesRegistered = true;
+        }
+        // CSS 2.1 names it "shift-JIS"; the registry knows it as "shift_jis".
+        var cleaned = name.Trim().Trim('"').Replace('-', '_');
+        try { return Encoding.GetEncoding(cleaned); }
+        catch (ArgumentException) { }
+        try { return Encoding.GetEncoding(name.Trim().Trim('"')); }
+        catch (ArgumentException) { return null; }
+    }
+
+    private static bool _codePagesRegistered;
 
     /// <summary>The initial font size — the value the root element inherits.</summary>
     internal const float DefaultFontSizePx = 16f;

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -2891,7 +2891,8 @@ internal static class Parser
     // agree; a selector declared twice keeps the last value, which is what the cascade would do
     // for equal specificity anyway.
 
-    private static readonly Dictionary<string, string> s_rawBackgrounds = new(StringComparer.Ordinal);
+    private static readonly Dictionary<string, (string Value, int Count)> s_rawBackgrounds =
+        new(StringComparer.Ordinal);
 
     private static void CollectRawBackgrounds(AngleSharp.Dom.IDocument document)
     {
@@ -2905,7 +2906,7 @@ internal static class Parser
         var i = 0;
         while (i < css.Length)
         {
-            var open = css.IndexOf('{', i);
+            var open = IndexOfSignificant(css, i, '{');
             if (open < 0) break;
             var close = MatchingBrace(css, open);
             if (close < 0) break;
@@ -2922,19 +2923,44 @@ internal static class Parser
             }
             else if (prelude.Length > 0 && LastBackgroundDeclaration(body) is { } bg)
             {
-                s_rawBackgrounds[CanonicalSelectorList(prelude)] = bg;
+                var key = CanonicalSelectorList(prelude);
+                var seen = s_rawBackgrounds.TryGetValue(key, out var prev) ? prev.Count : 0;
+                s_rawBackgrounds[key] = (bg, seen + 1);
             }
             i = close + 1;
         }
     }
 
+    /// <summary>Index of the next <paramref name="wanted"/> character that the CSS tokenizer would
+    /// actually see: one that is neither backslash-escaped nor inside a string. `p\{x` has no
+    /// block, and `content: "}"` does not close one — a scanner that misses either resynchronises
+    /// on the wrong brace and starts attributing declarations to the wrong selector.</summary>
+    private static int IndexOfSignificant(string s, int from, char wanted)
+    {
+        var quote = '\0';
+        for (var i = from; i < s.Length; i++)
+        {
+            var c = s[i];
+            if (c == '\\') { i++; continue; }
+            if (quote != '\0') { if (c == quote) quote = '\0'; continue; }
+            if (c is '"' or '\'') { quote = c; continue; }
+            if (c == wanted) return i;
+        }
+        return -1;
+    }
+
     private static int MatchingBrace(string s, int open)
     {
         var depth = 0;
+        var quote = '\0';
         for (var i = open; i < s.Length; i++)
         {
-            if (s[i] == '{') depth++;
-            else if (s[i] == '}' && --depth == 0) return i;
+            var c = s[i];
+            if (c == '\\') { i++; continue; }
+            if (quote != '\0') { if (c == quote) quote = '\0'; continue; }
+            if (c is '"' or '\'') { quote = c; continue; }
+            if (c == '{') depth++;
+            else if (c == '}' && --depth == 0) return i;
         }
         return -1;
     }
@@ -2962,18 +2988,32 @@ internal static class Parser
     {
         string? found = null;
         var depth = 0;
+        var braces = 0;
+        var sawBrace = false;
+        var quote = '\0';
         var start = 0;
         for (var i = 0; i <= body.Length; i++)
         {
             if (i < body.Length)
             {
-                if (body[i] == '(') { depth++; continue; }
-                if (body[i] == ')') { depth = Math.Max(0, depth - 1); continue; }
-                if (body[i] != ';' || depth != 0) continue;
+                var c = body[i];
+                if (c == '\\') { i++; continue; }
+                if (quote != '\0') { if (c == quote) quote = '\0'; continue; }
+                if (c is '"' or '\'') { quote = c; continue; }
+                if (c == '{') { braces++; sawBrace = true; continue; }
+                if (c == '}') { braces = Math.Max(0, braces - 1); continue; }
+                if (c == '(') { depth++; continue; }
+                if (c == ')') { depth = Math.Max(0, depth - 1); continue; }
+                if (c != ';' || depth != 0 || braces != 0) continue;
             }
             var decl = body[start..Math.Min(i, body.Length)];
             start = i + 1;
-            var colon = decl.IndexOf(':');
+            // A declaration containing a block is malformed (CSS 2.1 §4.2) and is dropped whole,
+            // so a `background` written inside one must not be read back out of it.
+            var hadBrace = sawBrace;
+            sawBrace = false;
+            if (hadBrace) continue;
+            var colon = IndexOfSignificant(decl, 0, ':');
             if (colon < 0) continue;
             if (!decl[..colon].Trim().Equals("background", StringComparison.OrdinalIgnoreCase)) continue;
             var value = decl[(colon + 1)..].Trim();
@@ -3025,16 +3065,20 @@ internal static class Parser
     /// <summary>The raw `background` shorthand declared for a rule's selector list, but only when
     /// AngleSharp lost the whole background family for that rule. When it kept anything — even a
     /// longhand written after the shorthand, which must win over it (§14.2 ordering) — its parse is
-    /// authoritative and re-expanding the source would clobber that ordering.</summary>
+    /// authoritative and re-expanding the source would clobber that ordering. A selector that
+    /// declares a background more than once is left alone too: the source order that decides
+    /// between them is not recoverable from the CSSOM rule alone, so abstaining keeps the engine
+    /// no worse than it was.</summary>
     private static string? RescuedBackgroundFor(ICssStyleRule styleRule)
     {
         if (string.IsNullOrEmpty(styleRule.SelectorText)) return null;
         if (!s_rawBackgrounds.TryGetValue(CanonicalSelectorList(styleRule.SelectorText), out var raw))
             return null;
+        if (raw.Count != 1) return null;
         var cssText = styleRule.Style?.CssText;
         if (!string.IsNullOrEmpty(cssText) &&
             cssText.Contains("background", StringComparison.OrdinalIgnoreCase)) return null;
-        return raw;
+        return raw.Value;
     }
 
     private static void CollectRulesFromSheet(ICssRuleList rules)

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -1253,17 +1253,32 @@ internal static class Parser
     /// </summary>
     private static void ExpandBackgroundShorthand(LayoutNode node, string value)
     {
-        var v = value.Trim();
-        if (v.Length == 0) return;
-        if (v is "initial" or "unset" or "none")
+        var longhands = SplitBackgroundShorthand(value);
+        if (longhands is null) return;
+        foreach (var (prop, val) in longhands)
         {
-            node.StyleOverrides["background-image"] = "none";
-            node.StyleOverrides["background-repeat"] = "repeat";
-            node.StyleOverrides["background-position"] = "0% 0%";
-            node.StyleOverrides["background-color"] = "transparent";
-            return;
+            if (val is null) node.StyleOverrides.Remove(prop);
+            else node.StyleOverrides[prop] = val;
         }
-        if (v == "inherit") return;   // leave the cascade to it
+    }
+
+    /// <summary>Decomposes a `background` shorthand (§14.2) into its longhands. A null value in the
+    /// result means "no declaration" (only ever background-color, which the shorthand leaves to
+    /// whatever the cascade already had when it names no colour). Returns null for 'inherit',
+    /// which the cascade resolves on its own, and for an empty value.</summary>
+    private static List<(string Prop, string? Val)>? SplitBackgroundShorthand(string value)
+    {
+        var v = value.Trim();
+        if (v.Length == 0) return null;
+        if (v is "initial" or "unset" or "none")
+            return
+            [
+                ("background-image", "none"),
+                ("background-repeat", "repeat"),
+                ("background-position", "0% 0%"),
+                ("background-color", "transparent"),
+            ];
+        if (v == "inherit") return null;   // leave the cascade to it
 
         string? image = null, repeat = null, attachment = null, color = null;
         var position = new List<string>();
@@ -1285,17 +1300,19 @@ internal static class Parser
         }
 
         // The shorthand resets everything it does not name to its initial value.
-        node.StyleOverrides["background-image"] = image ?? "none";
-        node.StyleOverrides["background-repeat"] = repeat ?? "repeat";
-        node.StyleOverrides["background-attachment"] = attachment ?? "scroll";
-        node.StyleOverrides["background-position"] = position.Count switch
-        {
-            0 => "0% 0%",
-            1 => position[0],
-            _ => $"{position[0]} {position[1]}",
-        };
-        if (color is not null) node.StyleOverrides["background-color"] = color;
-        else node.StyleOverrides.Remove("background-color");
+        return
+        [
+            ("background-image", image ?? "none"),
+            ("background-repeat", repeat ?? "repeat"),
+            ("background-attachment", attachment ?? "scroll"),
+            ("background-position", position.Count switch
+            {
+                0 => "0% 0%",
+                1 => position[0],
+                _ => $"{position[0]} {position[1]}",
+            }),
+            ("background-color", color),
+        ];
     }
 
     /// <summary>Splits a shorthand value on whitespace while keeping bracketed functions
@@ -2010,6 +2027,10 @@ internal static class Parser
                         StoreProp(node, prop, val);
                 }
                 ParseCssTextForFlexProps(styleRule.Style.CssText, node);
+                // Same rescue as the cascade path: re-apply the shorthand from the source when
+                // AngleSharp dropped it, after the CssText pass so the source wins.
+                if (RescuedBackgroundFor(styleRule) is { } rawBg)
+                    ExpandBackgroundShorthand(node, rawBg);
                 ExtractTransitionAndAnimation(styleRule.Style.CssText, node);
             }
             else
@@ -2851,9 +2872,169 @@ internal static class Parser
     private static void CollectCssRules(AngleSharp.Dom.IDocument document)
     {
         CssRules.Clear();
+        CollectRawBackgrounds(document);
         if (document.StyleSheets is null) return;
         foreach (var sheet in document.StyleSheets.OfType<ICssStyleSheet>())
             CollectRulesFromSheet(sheet.Rules);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 'background' shorthands rescued from the raw stylesheet text
+    // ─────────────────────────────────────────────────────────────────────────
+    //
+    // AngleSharp.Css drops a whole `background` declaration when the position is written as a bare
+    // keyword — `background: red url(x.png) right repeat-y` and `background: bottom green` both
+    // vanish, leaving the element with whatever a lower-specificity rule set. The value is
+    // perfectly good CSS 2.1 (§14.2), and the engine's own expander already understands it, so the
+    // shorthand is read straight out of the stylesheet source and re-applied over the CSSOM's
+    // version. Keyed by the rule's selector list, canonicalised so `body>div` and `body > div`
+    // agree; a selector declared twice keeps the last value, which is what the cascade would do
+    // for equal specificity anyway.
+
+    private static readonly Dictionary<string, string> s_rawBackgrounds = new(StringComparer.Ordinal);
+
+    private static void CollectRawBackgrounds(AngleSharp.Dom.IDocument document)
+    {
+        s_rawBackgrounds.Clear();
+        foreach (var styleEl in document.QuerySelectorAll("style"))
+            ScanRawBackgrounds(StripCssComments(styleEl.TextContent ?? string.Empty));
+    }
+
+    private static void ScanRawBackgrounds(string css)
+    {
+        var i = 0;
+        while (i < css.Length)
+        {
+            var open = css.IndexOf('{', i);
+            if (open < 0) break;
+            var close = MatchingBrace(css, open);
+            if (close < 0) break;
+
+            var prelude = css[i..open].Trim();
+            var body = css[(open + 1)..close];
+            if (prelude.StartsWith('@'))
+            {
+                // Conditional groups contain more style rules; everything else (@font-face,
+                // @keyframes, @page) has no selector to key on.
+                var name = prelude.Split(' ', '(', '\t', '\n', '\r')[0].ToLowerInvariant();
+                if (name is "@media" or "@supports" or "@document" or "@layer")
+                    ScanRawBackgrounds(body);
+            }
+            else if (prelude.Length > 0 && LastBackgroundDeclaration(body) is { } bg)
+            {
+                s_rawBackgrounds[CanonicalSelectorList(prelude)] = bg;
+            }
+            i = close + 1;
+        }
+    }
+
+    private static int MatchingBrace(string s, int open)
+    {
+        var depth = 0;
+        for (var i = open; i < s.Length; i++)
+        {
+            if (s[i] == '{') depth++;
+            else if (s[i] == '}' && --depth == 0) return i;
+        }
+        return -1;
+    }
+
+    private static string StripCssComments(string css)
+    {
+        if (!css.Contains("/*", StringComparison.Ordinal)) return css;
+        var sb = new System.Text.StringBuilder(css.Length);
+        var i = 0;
+        while (i < css.Length)
+        {
+            var start = css.IndexOf("/*", i, StringComparison.Ordinal);
+            if (start < 0) { sb.Append(css, i, css.Length - i); break; }
+            sb.Append(css, i, start - i);
+            var end = css.IndexOf("*/", start + 2, StringComparison.Ordinal);
+            if (end < 0) break;
+            i = end + 2;
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Returns the value of the last `background:` (not `background-*:`) declaration in a
+    /// rule body, with any !important flag removed, or null when the rule has none.</summary>
+    private static string? LastBackgroundDeclaration(string body)
+    {
+        string? found = null;
+        var depth = 0;
+        var start = 0;
+        for (var i = 0; i <= body.Length; i++)
+        {
+            if (i < body.Length)
+            {
+                if (body[i] == '(') { depth++; continue; }
+                if (body[i] == ')') { depth = Math.Max(0, depth - 1); continue; }
+                if (body[i] != ';' || depth != 0) continue;
+            }
+            var decl = body[start..Math.Min(i, body.Length)];
+            start = i + 1;
+            var colon = decl.IndexOf(':');
+            if (colon < 0) continue;
+            if (!decl[..colon].Trim().Equals("background", StringComparison.OrdinalIgnoreCase)) continue;
+            var value = decl[(colon + 1)..].Trim();
+            if (value.EndsWith("important", StringComparison.OrdinalIgnoreCase))
+            {
+                var head = value[..^"important".Length].TrimEnd();
+                if (head.EndsWith('!')) value = head[..^1].TrimEnd();
+            }
+            if (value.Length > 0) found = value;
+        }
+        return found;
+    }
+
+    /// <summary>Canonicalises a selector list so the stylesheet's own text and AngleSharp's
+    /// re-serialisation of it produce the same key: whitespace collapsed, spaces around
+    /// combinators removed, and the comma-separated parts sorted (order carries no meaning).</summary>
+    private static string CanonicalSelectorList(string selectors)
+    {
+        var parts = SplitSelectorList(selectors)
+            .Select(CanonicalSelector)
+            .Where(s => s.Length > 0)
+            .ToList();
+        parts.Sort(StringComparer.Ordinal);
+        return string.Join(',', parts);
+    }
+
+    private static string CanonicalSelector(string selector)
+    {
+        var sb = new System.Text.StringBuilder(selector.Length);
+        var pendingSpace = false;
+        foreach (var c in selector)
+        {
+            if (char.IsWhiteSpace(c)) { pendingSpace = sb.Length > 0; continue; }
+            if (c is '>' or '+' or '~')
+            {
+                while (sb.Length > 0 && sb[^1] == ' ') sb.Length--;
+                pendingSpace = false;
+            }
+            else if (pendingSpace && sb.Length > 0 && sb[^1] is not ('>' or '+' or '~'))
+            {
+                sb.Append(' ');
+            }
+            pendingSpace = false;
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>The raw `background` shorthand declared for a rule's selector list, but only when
+    /// AngleSharp lost the whole background family for that rule. When it kept anything — even a
+    /// longhand written after the shorthand, which must win over it (§14.2 ordering) — its parse is
+    /// authoritative and re-expanding the source would clobber that ordering.</summary>
+    private static string? RescuedBackgroundFor(ICssStyleRule styleRule)
+    {
+        if (string.IsNullOrEmpty(styleRule.SelectorText)) return null;
+        if (!s_rawBackgrounds.TryGetValue(CanonicalSelectorList(styleRule.SelectorText), out var raw))
+            return null;
+        var cssText = styleRule.Style?.CssText;
+        if (!string.IsNullOrEmpty(cssText) &&
+            cssText.Contains("background", StringComparison.OrdinalIgnoreCase)) return null;
+        return raw;
     }
 
     private static void CollectRulesFromSheet(ICssRuleList rules)
@@ -2867,9 +3048,19 @@ internal static class Parser
             }
             if (rule is not ICssStyleRule styleRule) continue;
 
-            var (props, important) = ParseDeclarations(styleRule.Style.CssText);
-            if (props.Count == 0) continue;
             if (string.IsNullOrEmpty(styleRule.SelectorText)) continue;
+
+            var (props, important) = ParseDeclarations(styleRule.Style.CssText);
+            // A `background` AngleSharp refused to parse never reaches CssText, so it is merged in
+            // from the stylesheet source before the empty-rule check — a rule whose only
+            // declaration is such a shorthand would otherwise be dropped outright.
+            if (RescuedBackgroundFor(styleRule) is { } rawBg &&
+                SplitBackgroundShorthand(rawBg) is { } rawLonghands)
+            {
+                foreach (var (prop, val) in rawLonghands)
+                    if (val is not null) props[prop] = val;
+            }
+            if (props.Count == 0) continue;
 
             // A selector list ("a, b") gets one entry per selector so each keeps its own specificity.
             foreach (var sel in SplitSelectorList(styleRule.SelectorText))

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -796,10 +796,14 @@ internal static class Parser
         if (element.ClassName != null)
             node.Attributes["class"] = element.ClassName;
 
-        // Capture data-* attributes for attribute selectors and getAttribute
+        // Capture every authored attribute, so attribute selectors, getAttribute and attr() in
+        // 'content' all see what the markup actually declared — only data-* and a per-tag
+        // whitelist used to survive, which left e.g. `td:before { content: attr(abbr) }` empty.
+        // Values the tag-specific blocks above normalised (an <input>'s value, a resolved src)
+        // are already in place and keep priority.
         foreach (var attr in element.Attributes)
         {
-            if (attr.Name.StartsWith("data-"))
+            if (!node.Attributes.ContainsKey(attr.Name))
                 node.Attributes[attr.Name] = attr.Value;
         }
 
@@ -1420,9 +1424,11 @@ internal static class Parser
         // Check if this is a simple single-token value
         if (!value.Contains("counter(") && !value.Contains("counters(") && !value.Contains("attr("))
         {
-            // Simple single value
-            if ((value.StartsWith('"') && value.EndsWith('"')) ||
-                (value.StartsWith('\'') && value.EndsWith('\'')))
+            // Simple single value. The length check matters: a lone quote character both starts
+            // and ends with a quote, and stripping one off each end of it asks for a -1 slice.
+            if (value.Length >= 2 &&
+                ((value.StartsWith('"') && value.EndsWith('"')) ||
+                 (value.StartsWith('\'') && value.EndsWith('\''))))
             {
                 var inner = value[1..^1];
                 return DecodeCssEscapes(inner);

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -607,9 +607,13 @@ internal static class Parser
             ? ""
             : NormalizeTextWhitespace(
                 string.Concat(element.ChildNodes.OfType<IText>().Select(t => t.Data)), ws);
+        // Trimming implements §16.6.1's "remove the spaces at the start and end of a line", so it
+        // only applies where 'white-space' collapses at all: under pre / pre-wrap every space is
+        // significant, and a cell holding one space is a space wide, not zero.
+        var preservesSpaces = ws is "pre" or "pre-wrap";
         var directText = hasMixedChildren
             ? ""   // text nodes become ordered #TEXT children below
-            : directTextRaw.Trim();
+            : preservesSpaces ? directTextRaw : directTextRaw.Trim();
 
         var href = tag == "A" ? element.GetAttribute("href") : null;
         var node = new LayoutNode(element.Id, tag, directText, elementStyle, href);
@@ -949,6 +953,7 @@ internal static class Parser
                     if (text.Length > 0)
                     {
                         var textChild = new LayoutNode(null, "#text", text, parentStyle);
+                        textChild.ResetNonInheritedStyles();
                         textChild.StyleOverrides[AngleSharp.Css.PropertyNames.Display] = "inline";
                         node.AddChild(textChild);
                     }
@@ -1068,6 +1073,7 @@ internal static class Parser
             var keepTrail = hasAfter && directTextRaw.Length > 0 && char.IsWhiteSpace(directTextRaw[^1]);
             var ownText = (keepLead ? " " : "") + node.DisplayText + (keepTrail ? " " : "");
             var textChild = new LayoutNode(null, "#text", ownText, node.Style);
+            textChild.ResetNonInheritedStyles();
             textChild.StyleOverrides["display"] = "inline";
             textChild.Parent = node;
             node.Children.Add(textChild);
@@ -1310,11 +1316,13 @@ internal static class Parser
         if (len <= 0) return;
 
         var letter = new LayoutNode(null, "#pseudo-first-letter", text[..len], host.Style);
+        letter.ResetNonInheritedStyles();
         letter.StyleOverrides["display"] = "inline";
         foreach (var (p, v) in styles)
             if (p != "content" && p != "display") letter.StyleOverrides[p] = v;
 
         var rest = new LayoutNode(null, "#text", text[len..], host.Style);
+        rest.ResetNonInheritedStyles();
         rest.StyleOverrides["display"] = "inline";
 
         // The host keeps its box (and its own styles) but hands its text to the two new children,

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -635,11 +635,16 @@ internal static class Parser
             node.Alt = element.GetAttribute("alt") ?? string.Empty;
             if (src != null) node.Attributes["src"] = src;   // source of truth for .src / .currentSrc
 
-            if (int.TryParse(element.GetAttribute("width"), out var w)) node.IntrinsicWidth = w;
-            if (int.TryParse(element.GetAttribute("height"), out var h)) node.IntrinsicHeight = h;
-
             if (!string.IsNullOrEmpty(src))
                 node.Image = ResourceLoader.FetchImage(src, _baseUrl);
+
+            // HTML presentational hints: width/height are lengths in px, or (HTML 4) percentages.
+            // They are CSS declarations, not the image's intrinsic size — mixing the two derived
+            // the "missing" dimension from the attribute of one axis and the bitmap of the other
+            // (width="100%" height="50" on a 1x1 image gave a height of 39200). The intrinsic size
+            // is the bitmap's; the attributes only stand in for it when there is no bitmap.
+            ApplyDimensionAttribute(element, node, "width", "width");
+            ApplyDimensionAttribute(element, node, "height", "height");
         }
 
         // <object>: a replaced element that renders its `data` resource, falling back to its
@@ -1197,6 +1202,40 @@ internal static class Parser
     }
 
     private static bool _codePagesRegistered;
+
+    /// <summary>
+    /// Maps an HTML <c>width</c>/<c>height</c> content attribute onto the node: a plain number is
+    /// the replaced element's intrinsic size in px, a percentage is a CSS length that resolves
+    /// against the containing block. Presentational hints lose to any author declaration, so they
+    /// are only applied where the element does not already carry one.
+    /// </summary>
+    private static void ApplyDimensionAttribute(IElement element, LayoutNode node, string attribute, string property)
+    {
+        var raw = element.GetAttribute(attribute)?.Trim();
+        if (string.IsNullOrEmpty(raw)) return;
+
+        if (raw.EndsWith("%", StringComparison.Ordinal) &&
+            float.TryParse(raw[..^1], System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var pct))
+        {
+            var declared = element.ComputeCurrentStyle().GetPropertyValueSafe(property)?.Trim();
+            if (string.IsNullOrEmpty(declared) || declared == "auto")
+                node.StyleOverrides[property] = $"{pct.ToString(System.Globalization.CultureInfo.InvariantCulture)}%";
+            return;
+        }
+        if (int.TryParse(raw, out var px))
+        {
+            var declared = element.ComputeCurrentStyle().GetPropertyValueSafe(property)?.Trim();
+            if (string.IsNullOrEmpty(declared) || declared == "auto")
+                node.StyleOverrides[property] = $"{px}px";
+            // With no bitmap to measure, the attribute is all the intrinsic size there is.
+            if (node.Image is null)
+            {
+                if (property == "width") node.IntrinsicWidth = px;
+                else node.IntrinsicHeight = px;
+            }
+        }
+    }
 
     /// <summary>The initial font size — the value the root element inherits.</summary>
     internal const float DefaultFontSizePx = 16f;

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -1237,6 +1237,82 @@ internal static class Parser
         }
     }
 
+    /// <summary>
+    /// Splits a 'background' shorthand into the longhands the painter reads (§14.2). AngleSharp
+    /// drops the whole declaration when any component is one it will not parse — `background:
+    /// bottom green` loses the colour as well as the position — and the shorthand also has to
+    /// reset the components it does not mention, which is what makes `background: green` clear an
+    /// inherited-looking image. Tokens are classified by shape, so their order does not matter.
+    /// </summary>
+    private static void ExpandBackgroundShorthand(LayoutNode node, string value)
+    {
+        var v = value.Trim();
+        if (v.Length == 0) return;
+        if (v is "initial" or "unset" or "none")
+        {
+            node.StyleOverrides["background-image"] = "none";
+            node.StyleOverrides["background-repeat"] = "repeat";
+            node.StyleOverrides["background-position"] = "0% 0%";
+            node.StyleOverrides["background-color"] = "transparent";
+            return;
+        }
+        if (v == "inherit") return;   // leave the cascade to it
+
+        string? image = null, repeat = null, attachment = null, color = null;
+        var position = new List<string>();
+
+        foreach (var token in SplitBackgroundTokens(v))
+        {
+            var t = token.Trim();
+            if (t.Length == 0) continue;
+            var lower = t.ToLowerInvariant();
+
+            if (lower.StartsWith("url(", StringComparison.Ordinal) || lower == "none") image = t;
+            else if (lower is "repeat" or "repeat-x" or "repeat-y" or "no-repeat") repeat = lower;
+            else if (lower is "scroll" or "fixed" or "local") attachment = lower;
+            else if (lower is "left" or "right" or "top" or "bottom" or "center"
+                     || lower.EndsWith("%", StringComparison.Ordinal)
+                     || char.IsAsciiDigit(lower[0]) || lower[0] == '.' || lower[0] == '-')
+                position.Add(lower);
+            else color = t;   // a colour keyword or function
+        }
+
+        // The shorthand resets everything it does not name to its initial value.
+        node.StyleOverrides["background-image"] = image ?? "none";
+        node.StyleOverrides["background-repeat"] = repeat ?? "repeat";
+        node.StyleOverrides["background-attachment"] = attachment ?? "scroll";
+        node.StyleOverrides["background-position"] = position.Count switch
+        {
+            0 => "0% 0%",
+            1 => position[0],
+            _ => $"{position[0]} {position[1]}",
+        };
+        if (color is not null) node.StyleOverrides["background-color"] = color;
+        else node.StyleOverrides.Remove("background-color");
+    }
+
+    /// <summary>Splits a shorthand value on whitespace while keeping bracketed functions
+    /// (<c>url(…)</c>, <c>rgba(…)</c>) in one piece.</summary>
+    private static List<string> SplitBackgroundTokens(string value)
+    {
+        var tokens = new List<string>();
+        var depth = 0;
+        var start = 0;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c == '(') depth++;
+            else if (c == ')') depth = Math.Max(0, depth - 1);
+            else if (char.IsWhiteSpace(c) && depth == 0)
+            {
+                if (i > start) tokens.Add(value[start..i]);
+                start = i + 1;
+            }
+        }
+        if (start < value.Length) tokens.Add(value[start..]);
+        return tokens;
+    }
+
     /// <summary>The initial font size — the value the root element inherits.</summary>
     internal const float DefaultFontSizePx = 16f;
 
@@ -1977,7 +2053,11 @@ internal static class Parser
 
     private static void StoreProp(LayoutNode node, string prop, string val)
     {
-        if (prop == "gap")
+        if (prop == "background")
+        {
+            ExpandBackgroundShorthand(node, val);
+        }
+        else if (prop == "gap")
         {
             var parts = val.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             node.StyleOverrides["row-gap"] = parts[0];
@@ -2163,8 +2243,10 @@ internal static class Parser
                 continue;
             }
 
-            // Only extract our target properties
-            if (Array.IndexOf(s_extraProps, prop) >= 0)
+            // Only extract our target properties. 'background' is handled from the DECLARED text
+            // only — never from AngleSharp's synthesized shorthand, which every rule reports a
+            // value for and would reset the longhands of rules that never mentioned it.
+            if (prop == "background" || Array.IndexOf(s_extraProps, prop) >= 0)
                 StoreProp(node, prop, val);
         }
     }

--- a/Lite/Parser.cs
+++ b/Lite/Parser.cs
@@ -1966,6 +1966,7 @@ internal static class Parser
         // NeutralizePseudoElementRules), so they are applied here from the recorded originals.
         foreach (var (selector, style) in _pseudoElementRules)
             TryExtractPseudoElementRule(element, node, selector, style);
+
     }
 
     /// <summary>
@@ -2957,10 +2958,16 @@ internal static class Parser
             if (colon < 0) continue;
             var prop = decl[..colon].Trim().ToLowerInvariant();
             var raw = decl[(colon + 1)..].Trim();
-            if (raw.EndsWith("!important", StringComparison.OrdinalIgnoreCase))
+            // "!important" may be written with whitespace after the bang ("! important"), which
+            // is what the CSS 2.1 test suite does — matching the literal token alone missed it.
+            if (raw.EndsWith("important", StringComparison.OrdinalIgnoreCase))
             {
-                raw = raw[..^"!important".Length].Trim();
-                important.Add(prop);
+                var head = raw[..^"important".Length].TrimEnd();
+                if (head.EndsWith('!'))
+                {
+                    raw = head[..^1].TrimEnd();
+                    important.Add(prop);
+                }
             }
             if (!string.IsNullOrEmpty(raw)) props[prop] = raw;
         }

--- a/Lite/Scripting/Dom/JsFetch.cs
+++ b/Lite/Scripting/Dom/JsFetch.cs
@@ -85,11 +85,6 @@ internal static class JsFetch
         return new FetchResult { ok = true, status = 200, statusText = "OK", body = text };
     }
 
-    private static string ResolveUrl(string src, string? baseUrl)
-    {
-        if (Uri.TryCreate(src, UriKind.Absolute, out _)) return src;
-        if (baseUrl is not null && Uri.TryCreate(new Uri(baseUrl), src, out var resolved))
-            return resolved.ToString();
-        return src;
-    }
+    private static string ResolveUrl(string src, string? baseUrl) =>
+        Lite.Network.UrlUtils.Resolve(src, baseUrl) ?? src;
 }

--- a/Lite/Scripting/JsEngine.cs
+++ b/Lite/Scripting/JsEngine.cs
@@ -114,7 +114,8 @@ internal class JsEngine
     internal string? ResolveAgainstCurrent(string? url)
     {
         if (url is null) return null;
-        if (Uri.TryCreate(url, UriKind.Absolute, out var abs)) return abs.AbsoluteUri;
+        if (Lite.Network.UrlUtils.IsAbsolute(url) && Uri.TryCreate(url, UriKind.Absolute, out var abs))
+            return abs.AbsoluteUri;
         if (Uri.TryCreate(CurrentUrl, UriKind.Absolute, out var baseUri) &&
             Uri.TryCreate(baseUri, url, out var resolved))
             return resolved.AbsoluteUri;

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ pass rate — informational, never gating:
 dotnet run --project Lite.Conformance -- --suite css21 --survey css/CSS2/normal-flow
 ```
 
-Across the full upstream `css/CSS2` reftest suite Lite currently passes **3917 / 6266 (62.5%)**.
+Across the full upstream `css/CSS2` reftest suite Lite currently passes **4042 / 6266 (64.5%)**.
 Diagnostics: `--render <url> [name]` dumps one page to `artifacts/<name>.png`, and
 `--geom <url> <selector>` prints the resolved geometry of matching elements.
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ pass rate — informational, never gating:
 dotnet run --project Lite.Conformance -- --suite css21 --survey css/CSS2/normal-flow
 ```
 
-Across the full upstream `css/CSS2` reftest suite Lite currently passes **3842 / 6266 (61.3%)**.
+Across the full upstream `css/CSS2` reftest suite Lite currently passes **3917 / 6266 (62.5%)**.
 Diagnostics: `--render <url> [name]` dumps one page to `artifacts/<name>.png`, and
 `--geom <url> <selector>` prints the resolved geometry of matching elements.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Lite is a lightweight HTML/CSS/JS rendering engine for Windows, written in C#. I
 | `Lite/`       | Class library | The rendering engine and `BrowserWindow` API                        |
 | `Lite.Media/` | Class library | Optional LibVLC-backed audio/video playback (`VlcMedia.Register()`) |
 | `Example/`    | Executable    | Demo app using the library with a local HTML/CSS/JS site            |
+| `Lite.Tests/` | Executable    | Zero-dependency unit-test runner (`dotnet run --project Lite.Tests`) |
+| `Lite.Conformance/` | Executable | CSS 2.1 / WPT / test262 / Acid conformance harness                  |
 
 ---
 
@@ -536,6 +538,35 @@ dotnet run --project Example
 ```
 
 The example serves the `Example/resources/` folder on `http://localhost:4444` and opens it in a `BrowserWindow`. It is a multi-page site — typography, colors, layout, lists & tables, forms, graphics, transforms & animations, and JavaScript DOM — linked by an in-app nav bar, so clicking through it exercises in-page navigation and the loading animation. Between them the pages cover inline text elements, lists, forms (text, password, number, range, radio, checkbox, textarea, select) with submission and validation, flexbox layouts, tables, positioning, z-index, overflow clipping, percentage sizing, pseudo-classes (:hover/:focus/:active and structural/form), pseudo-elements (::before/::after), responsive design (@media), CSS animations/transitions (with lifecycle events), calc() expressions, CSS custom properties (var()), text transforms, letter/word spacing, border styles, outlines, background images, vertical alignment, table border collapse, linear gradients, CSS 2D transforms, CSS filters, text-overflow ellipsis, position:sticky, aspect-ratio, pointer-events, dataset, animation-play-state, programmatic scrolling, fetch, Web Storage, and ES modules.
+
+---
+
+## Conformance
+
+`Lite.Conformance` runs the engine against real test suites. Test files are vendored by
+`scripts/fetch-tests.ps1` at pinned commits and are not checked in.
+
+```bash
+dotnet run --project Lite.Conformance -- --suite css21     # curated CSS 2.1 reftest gate
+dotnet run --project Lite.Conformance -- --suite wpt       # Web Platform Tests
+dotnet run --project Lite.Conformance -- --suite test262   # JavaScript
+dotnet run --project Lite.Conformance -- --suite acid      # Acid1 / Acid2 against approved baselines
+```
+
+Exit code 0 means green: no unexpected failures and no unexpected passes. Both sides of a
+reftest are rendered by Lite and pixel-compared, so font rasterization differences cancel
+out and only layout/paint differences register.
+
+Beyond the curated gate, `--survey <dir>` measures a whole upstream directory and reports a
+pass rate — informational, never gating:
+
+```bash
+dotnet run --project Lite.Conformance -- --suite css21 --survey css/CSS2/normal-flow
+```
+
+Across the full upstream `css/CSS2` reftest suite Lite currently passes **3554 / 6266 (56.7%)**.
+Diagnostics: `--render <url> [name]` dumps one page to `artifacts/<name>.png`, and
+`--geom <url> <selector>` prints the resolved geometry of matching elements.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ pass rate — informational, never gating:
 dotnet run --project Lite.Conformance -- --suite css21 --survey css/CSS2/normal-flow
 ```
 
-Across the full upstream `css/CSS2` reftest suite Lite currently passes **3814 / 6266 (60.9%)**.
+Across the full upstream `css/CSS2` reftest suite Lite currently passes **3842 / 6266 (61.3%)**.
 Diagnostics: `--render <url> [name]` dumps one page to `artifacts/<name>.png`, and
 `--geom <url> <selector>` prints the resolved geometry of matching elements.
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ pass rate — informational, never gating:
 dotnet run --project Lite.Conformance -- --suite css21 --survey css/CSS2/normal-flow
 ```
 
-Across the full upstream `css/CSS2` reftest suite Lite currently passes **3812 / 6266 (60.8%)**.
+Across the full upstream `css/CSS2` reftest suite Lite currently passes **3814 / 6266 (60.9%)**.
 Diagnostics: `--render <url> [name]` dumps one page to `artifacts/<name>.png`, and
 `--geom <url> <selector>` prints the resolved geometry of matching elements.
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ pass rate — informational, never gating:
 dotnet run --project Lite.Conformance -- --suite css21 --survey css/CSS2/normal-flow
 ```
 
-Across the full upstream `css/CSS2` reftest suite Lite currently passes **3554 / 6266 (56.7%)**.
+Across the full upstream `css/CSS2` reftest suite Lite currently passes **3812 / 6266 (60.8%)**.
 Diagnostics: `--render <url> [name]` dumps one page to `artifacts/<name>.png`, and
 `--geom <url> <selector>` prints the resolved geometry of matching elements.
 


### PR DESCRIPTION
Restores the CSS 2.1 layout work that commit 985c675 reverted (the changelog for
0.0.13 describes it as present): position:fixed painting, inline-block background
and border painting, §9.7 float/abspos blockification, §10.3.2/§10.6.2 replaced-box
intrinsic sizing, and §9.5.1 float-joins-the-current-line placement. Their unit
tests were left in the tree and had been failing since.

On top of that:

- ::first-letter (§5.12.1) is generated as a real inline box during parsing instead
  of being re-drawn at paint time, so it contributes its font metrics, line-height
  and width to the line box and paints every property through the ordinary inline
  path. The paint-time version supported only color/font-size/font-weight and never
  affected layout, so a larger first letter left the line box sized for the parent
  font. Upstream css/CSS2/selectors goes 93/545 -> 490/545.

- Absolutely positioned boxes now use their static position (§10.3.7 / §10.6.4) when
  the corresponding offsets are auto: the normal-flow pass records the flow point
  each out-of-flow child passes over, and an abs-pos box inside an inline run rides
  along on the line as a zero-sized marker, so it also no longer splits that line in
  two. Previously such a box was pinned to its containing block's origin.

- Line boxes get a per-line float band (§9.5): a float now shortens only the lines it
  is actually beside, and text-align resolves against the line's own band.

- URL resolution goes through a shared UrlUtils that treats only a real scheme as
  absolute. Uri.TryCreate(UriKind.Absolute) accepts "/fonts/ahem.css" as an implicit
  file: URI on Unix, so every root-relative stylesheet, image and form action was
  passed to the HTTP client unresolved.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018628vGeHQTduuazWd2LGm1